### PR TITLE
Add support for chain local exception handlers

### DIFF
--- a/ask-sdk-core/src/com/amazon/ask/dispatcher/request/handler/RequestHandlerChain.java
+++ b/ask-sdk-core/src/com/amazon/ask/dispatcher/request/handler/RequestHandlerChain.java
@@ -13,6 +13,7 @@
 
 package com.amazon.ask.dispatcher.request.handler;
 
+import com.amazon.ask.dispatcher.exception.ExceptionHandler;
 import com.amazon.ask.dispatcher.request.interceptor.RequestInterceptor;
 import com.amazon.ask.dispatcher.request.interceptor.ResponseInterceptor;
 
@@ -30,8 +31,19 @@ public interface RequestHandlerChain {
      */
     Object getRequestHandler();
 
+    /**
+     * @return list of chain-level request interceptors
+     */
     List<RequestInterceptor> getRequestInterceptors();
 
+    /**
+     * @return list of chain-level response interceptors
+     */
     List<ResponseInterceptor> getResponseInterceptors();
+
+    /**
+     * @return list of chain-level exception handlers
+     */
+    List<ExceptionHandler> getExceptionHandlers();
 
 }

--- a/ask-sdk-core/src/com/amazon/ask/dispatcher/request/handler/impl/DefaultRequestHandlerChain.java
+++ b/ask-sdk-core/src/com/amazon/ask/dispatcher/request/handler/impl/DefaultRequestHandlerChain.java
@@ -13,10 +13,11 @@
 
 package com.amazon.ask.dispatcher.request.handler.impl;
 
+import com.amazon.ask.dispatcher.exception.ExceptionHandler;
+import com.amazon.ask.dispatcher.request.handler.RequestHandler;
 import com.amazon.ask.dispatcher.request.handler.RequestHandlerChain;
 import com.amazon.ask.dispatcher.request.interceptor.RequestInterceptor;
 import com.amazon.ask.dispatcher.request.interceptor.ResponseInterceptor;
-import com.amazon.ask.dispatcher.request.handler.RequestHandler;
 
 import java.util.List;
 
@@ -26,8 +27,9 @@ import java.util.List;
 public class DefaultRequestHandlerChain extends GenericRequestHandlerChain {
 
     protected DefaultRequestHandlerChain(RequestHandler handler, List<RequestInterceptor> requestInterceptors,
-                                         List<ResponseInterceptor> responseInterceptors) {
-        super(handler, requestInterceptors, responseInterceptors);
+                                         List<ResponseInterceptor> responseInterceptors,
+                                         List<ExceptionHandler> exceptionHandlers) {
+        super(handler, requestInterceptors, responseInterceptors, exceptionHandlers);
     }
 
     public static Builder builder() {
@@ -51,7 +53,7 @@ public class DefaultRequestHandlerChain extends GenericRequestHandlerChain {
         }
 
         public DefaultRequestHandlerChain build() {
-            return new DefaultRequestHandlerChain(handler, requestInterceptors, responseInterceptors);
+            return new DefaultRequestHandlerChain(handler, requestInterceptors, responseInterceptors, exceptionHandlers);
         }
     }
 }

--- a/ask-sdk-core/src/com/amazon/ask/dispatcher/request/handler/impl/GenericRequestHandlerChain.java
+++ b/ask-sdk-core/src/com/amazon/ask/dispatcher/request/handler/impl/GenericRequestHandlerChain.java
@@ -13,9 +13,10 @@
 
 package com.amazon.ask.dispatcher.request.handler.impl;
 
+import com.amazon.ask.dispatcher.exception.ExceptionHandler;
+import com.amazon.ask.dispatcher.request.handler.RequestHandlerChain;
 import com.amazon.ask.dispatcher.request.interceptor.RequestInterceptor;
 import com.amazon.ask.dispatcher.request.interceptor.ResponseInterceptor;
-import com.amazon.ask.dispatcher.request.handler.RequestHandlerChain;
 import com.amazon.ask.util.ValidationUtils;
 
 import java.util.ArrayList;
@@ -25,12 +26,15 @@ public class GenericRequestHandlerChain implements RequestHandlerChain {
     protected final Object handler;
     protected final List<RequestInterceptor> requestInterceptors;
     protected final List<ResponseInterceptor> responseInterceptors;
+    protected final List<ExceptionHandler> exceptionHandlers;
 
     protected GenericRequestHandlerChain(Object handler, List<RequestInterceptor> requestInterceptors,
-                                         List<ResponseInterceptor> responseInterceptors) {
+                                         List<ResponseInterceptor> responseInterceptors,
+                                         List<ExceptionHandler> exceptionHandlers) {
         this.handler = ValidationUtils.assertNotNull(handler, "handler");
         this.requestInterceptors = requestInterceptors != null ? requestInterceptors : new ArrayList<>();
         this.responseInterceptors = responseInterceptors != null ? responseInterceptors : new ArrayList<>();
+        this.exceptionHandlers = exceptionHandlers != null ? exceptionHandlers : new ArrayList<>();
     }
 
     public static Builder builder() {
@@ -52,11 +56,15 @@ public class GenericRequestHandlerChain implements RequestHandlerChain {
         return responseInterceptors;
     }
 
+    @Override
+    public List<ExceptionHandler> getExceptionHandlers() { return exceptionHandlers; }
+
     @SuppressWarnings("unchecked")
     public static class Builder<T extends Builder<T>> {
         protected Object handler;
         protected List<RequestInterceptor> requestInterceptors;
         protected List<ResponseInterceptor> responseInterceptors;
+        protected List<ExceptionHandler> exceptionHandlers;
 
         protected Builder() {
         }
@@ -92,8 +100,21 @@ public class GenericRequestHandlerChain implements RequestHandlerChain {
             return (T) this;
         }
 
+        public T withExceptionHandlers(List<ExceptionHandler> exceptionHandlers) {
+            this.exceptionHandlers = exceptionHandlers;
+            return (T) this;
+        }
+
+        public T addExceptionHandler(ExceptionHandler exceptionHandler) {
+            if (exceptionHandlers == null) {
+                exceptionHandlers = new ArrayList<>();
+            }
+            exceptionHandlers.add(exceptionHandler);
+            return (T) this;
+        }
+
         public GenericRequestHandlerChain build() {
-            return new GenericRequestHandlerChain(handler, requestInterceptors, responseInterceptors);
+            return new GenericRequestHandlerChain(handler, requestInterceptors, responseInterceptors, exceptionHandlers);
         }
     }
 }

--- a/ask-sdk-core/src/com/amazon/ask/dispatcher/request/mapper/impl/DefaultRequestMapper.java
+++ b/ask-sdk-core/src/com/amazon/ask/dispatcher/request/mapper/impl/DefaultRequestMapper.java
@@ -40,7 +40,7 @@ public class DefaultRequestMapper implements RequestMapper {
         return handlerChains.stream()
                 .filter(handlerChain -> handlerChain.getRequestHandler().canHandle(input))
                 .map(handlerChain -> (RequestHandlerChain) handlerChain)
-                .findAny();
+                .findFirst();
     }
 
     public static class Builder {


### PR DESCRIPTION
## Description
Allows local exception handlers to be registered on a RequestHandlerChain. Chain level exception handlers will be accessed first for any exception occurring within chain level processing (chain 
 level request/response interceptors and request handler execution), falling back to global exception handlers if necessary. Exceptions occurring outside of the context of the chain will always hit global exception handlers.

## Testing
Updated unit tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

[issues]: https://github.com/alexa/alexa-skills-kit-sdk-for-java/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement

