### PR TITLE
Enable consistent reads through the DDB persistence adapter

### DIFF
--- a/ask-sdk-dynamodb-persistence-adapter/src/com/amazon/ask/attributes/persistence/impl/DynamoDbPersistenceAdapter.java
+++ b/ask-sdk-dynamodb-persistence-adapter/src/com/amazon/ask/attributes/persistence/impl/DynamoDbPersistenceAdapter.java
@@ -75,7 +75,8 @@ public final class DynamoDbPersistenceAdapter implements PersistenceAdapter {
         String partitionKey = partitionKeyGenerator.apply(envelope);
         GetItemRequest request = new GetItemRequest()
                 .withTableName(tableName)
-                .withKey(Collections.singletonMap(partitionKeyName, new AttributeValue().withS(partitionKey)));
+                .withKey(Collections.singletonMap(partitionKeyName, new AttributeValue().withS(partitionKey)))
+                .withConsistentRead(true);
         Map<String, AttributeValue> result = null;
         try {
             result = dynamoDb.getItem(request).getItem();


### PR DESCRIPTION
## Description
Sets the consistent read flag to true on the GetItem request made to DynamoDB to retrieve persistent attributes to ensure read-after-write consistency.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

[issues]: https://github.com/alexa/alexa-skills-kit-sdk-for-java/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement

