### PR TITLE
Custom proxy properly set on servlet signature verifier

### DIFF
--- a/ask-sdk-servlet-support/src/com/amazon/ask/servlet/SkillServlet.java
+++ b/ask-sdk-servlet-support/src/com/amazon/ask/servlet/SkillServlet.java
@@ -63,11 +63,10 @@ public class SkillServlet extends HttpServlet {
     private transient final Skill skill;
     private transient final List<SkillServletVerifier> verifiers;
     private transient final Serializer serializer = new JacksonSerializer();
-    private transient Proxy proxy = Proxy.NO_PROXY;
 
     public SkillServlet(Skill skill) {
         List<SkillServletVerifier> defaultVerifiers = new ArrayList<>();
-        defaultVerifiers.add(new SkillRequestSignatureVerifier(proxy));
+        defaultVerifiers.add(new SkillRequestSignatureVerifier(Proxy.NO_PROXY));
         Long timestampToleranceProperty = ServletUtils.getSystemPropertyAsLong(TIMESTAMP_TOLERANCE_SYSTEM_PROPERTY);
         defaultVerifiers.add(new SkillRequestTimestampVerifier(timestampToleranceProperty != null
                 ? timestampToleranceProperty : DEFAULT_TOLERANCE_MILLIS));
@@ -129,7 +128,9 @@ public class SkillServlet extends HttpServlet {
      * @param proxy the {@code Proxy} to associate with this servlet.
      */
     public void setProxy(Proxy proxy) {
-        this.proxy = proxy;
+        if (verifiers.removeIf(verifier -> verifier instanceof SkillRequestSignatureVerifier)) {
+            verifiers.add(new SkillRequestSignatureVerifier(proxy));
+        }
     }
 
     private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {

--- a/ask-sdk-servlet-support/tst/com/amazon/ask/servlet/SkillServletTest.java
+++ b/ask-sdk-servlet-support/tst/com/amazon/ask/servlet/SkillServletTest.java
@@ -39,6 +39,8 @@ import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
+import java.net.InetSocketAddress;
+import java.net.Proxy;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.util.Collections;
@@ -49,7 +51,7 @@ import java.util.Date;
  * its behavior.
  */
 @RunWith(PowerMockRunner.class)
-@PrepareForTest(SkillRequestSignatureVerifier.class)
+@PrepareForTest({SkillRequestSignatureVerifier.class, SkillServlet.class})
 public class SkillServletTest extends SkillServletTestBase {
     private static final String LOCALE = "en-US";
     private static Skill skill;
@@ -108,6 +110,18 @@ public class SkillServletTest extends SkillServletTestBase {
         servlet.doPost(invocation.request, invocation.response);
         byte[] output = invocation.output.toByteArray();
         assertTrue(output.length > 0);
+    }
+
+    @Test
+    public void custom_proxy_updates_signature_verifier() throws Exception {
+        SkillServlet servlet = new SkillServlet(skill);
+        Proxy proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress("10.0.0.1", 8080));
+        SkillRequestSignatureVerifier mockVerifier = mock(SkillRequestSignatureVerifier.class);
+        PowerMockito.whenNew(SkillRequestSignatureVerifier.class)
+                .withArguments(proxy)
+                .thenReturn(mockVerifier);
+        servlet.setProxy(proxy);
+        PowerMockito.verifyNew(SkillRequestSignatureVerifier.class).withArguments(proxy);
     }
 
 }


### PR DESCRIPTION
## Description
Fixes a follow up issue in #132 where calling `setProxy` would not actually update the request signature verifier. This change fixes that while without breaking the API.

## Motivation and Context
Customer reported bug in the skill servlet.

## Testing
Unit tested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

[issues]: https://github.com/alexa/alexa-skills-kit-sdk-for-java/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement

