### PR TITLE
Don't force NO_PROXY proxy setting if a proxy is not provided

### DIFF
--- a/ask-sdk-servlet-support/src/com/amazon/ask/servlet/verifiers/SkillRequestSignatureVerifier.java
+++ b/ask-sdk-servlet-support/src/com/amazon/ask/servlet/verifiers/SkillRequestSignatureVerifier.java
@@ -55,7 +55,7 @@ public final class SkillRequestSignatureVerifier implements SkillServletVerifier
     private final Proxy proxy;
 
     public SkillRequestSignatureVerifier() {
-        this(Proxy.NO_PROXY);
+        this.proxy = null;
     }
 
     /**
@@ -124,7 +124,8 @@ public final class SkillRequestSignatureVerifier implements SkillServletVerifier
     private X509Certificate retrieveAndVerifyCertificateChain(
             final String signingCertificateChainUrl) throws CertificateException {
         try (InputStream in =
-                getAndVerifySigningCertificateChainUrl(signingCertificateChainUrl).openConnection(proxy).getInputStream()) {
+                proxy != null ? getAndVerifySigningCertificateChainUrl(signingCertificateChainUrl).openConnection(proxy).getInputStream()
+                : getAndVerifySigningCertificateChainUrl(signingCertificateChainUrl).openConnection().getInputStream()) {
             CertificateFactory certificateFactory =
                     CertificateFactory.getInstance(ServletConstants.SIGNATURE_CERTIFICATE_TYPE);
             @SuppressWarnings("unchecked")


### PR DESCRIPTION
## Description
Change #132 introduced a configurable Proxy option for skill servlets. This proxy is used during certificate retrieval. However, because the change also sets an explicit NO_PROXY setting when a proxy is not provided, users who previously configured their proxy through JVM environment variables are no longer having those settings honored. This change restores the original behavior while retaining the ability to explicitly provide a proxy to the servlet.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

[issues]: https://github.com/alexa/alexa-skills-kit-sdk-for-java/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement

