### PR TITLE
Add ability to disable servlet request signature verification

### DIFF
--- a/ask-sdk-servlet-support/src/com/amazon/ask/servlet/ServletConstants.java
+++ b/ask-sdk-servlet-support/src/com/amazon/ask/servlet/ServletConstants.java
@@ -53,6 +53,16 @@ public final class ServletConstants {
             "SignatureCertChainUrl";
 
     /**
+     * The name of the system property that can be used to disable request signature verification.
+     * This feature verifies the certificate authenticity using the configured TrustStore and the
+     * signature of the skill request, and will throw a {@link SecurityException} if the signature
+     * does not pass verification. This feature should only be disabled in testing scenarios and
+     * never in a production environment.
+     */
+    public static final String DISABLE_REQUEST_SIGNATURE_CHECK_SYSTEM_PROPERTY =
+            "com.amazon.ask.servlet.disableRequestSignatureCheck";
+
+    /**
      * The name of the system property that can be used to configure the timestamp tolerance (in
      * millis) of the {@link SkillServlet}. Requests with timestamps outside of this inclusive tolerance range,
      * either in the past or future, are rejected. If this property is not provided the default value,

--- a/ask-sdk-servlet-support/src/com/amazon/ask/servlet/SkillServlet.java
+++ b/ask-sdk-servlet-support/src/com/amazon/ask/servlet/SkillServlet.java
@@ -66,7 +66,9 @@ public class SkillServlet extends HttpServlet {
 
     public SkillServlet(Skill skill) {
         List<SkillServletVerifier> defaultVerifiers = new ArrayList<>();
-        defaultVerifiers.add(new SkillRequestSignatureVerifier());
+        if (!Boolean.parseBoolean(System.getProperty(ServletConstants.DISABLE_REQUEST_SIGNATURE_CHECK_SYSTEM_PROPERTY))) {
+            defaultVerifiers.add(new SkillRequestSignatureVerifier());
+        }
         Long timestampToleranceProperty = ServletUtils.getSystemPropertyAsLong(TIMESTAMP_TOLERANCE_SYSTEM_PROPERTY);
         defaultVerifiers.add(new SkillRequestTimestampVerifier(timestampToleranceProperty != null
                 ? timestampToleranceProperty : DEFAULT_TOLERANCE_MILLIS));


### PR DESCRIPTION
## Description
Ports the v1 servlet functionality allowing a user to disable request signature verification on the skill servlet by setting a system property. This allows for local testing, as reported in #161.

## Motivation and Context
#161 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

[issues]: https://github.com/alexa/alexa-skills-kit-sdk-for-java/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement

