### PR TITLE
Add a constructor to support tolerance for various time units

### DIFF
--- a/ask-sdk-servlet-support/src/com/amazon/ask/servlet/verifiers/SkillRequestTimestampVerifier.java
+++ b/ask-sdk-servlet-support/src/com/amazon/ask/servlet/verifiers/SkillRequestTimestampVerifier.java
@@ -16,8 +16,11 @@ package com.amazon.ask.servlet.verifiers;
 import com.amazon.ask.model.Request;
 import com.amazon.ask.model.RequestEnvelope;
 import com.amazon.ask.servlet.ServletConstants;
+import com.amazon.ask.util.ValidationUtils;
 
 import javax.servlet.http.HttpServletRequest;
+
+import java.util.concurrent.TimeUnit;
 
 import static com.amazon.ask.servlet.ServletConstants.MAXIMUM_TOLERANCE_MILLIS;
 
@@ -53,6 +56,19 @@ public class SkillRequestTimestampVerifier implements SkillServletVerifier {
             throw new IllegalArgumentException("A negative tolerance is not supported");
         }
         this.toleranceInMilliseconds = toleranceInMilliseconds;
+    }
+
+    /**
+     * Constructs a new timestamp verifier with the provided tolerance and timeUnit.
+     *
+     * @param tolerance
+     *            the tolerance of this verifier must be non-negative and less than
+     *            {@value ServletConstants#MAXIMUM_TOLERANCE_MILLIS} after converting to milliseconds.
+     * @param timeUnit
+     *            {@link TimeUnit} must be non-null.
+     */
+    public SkillRequestTimestampVerifier(long tolerance, TimeUnit timeUnit) {
+        this(ValidationUtils.assertNotNull(timeUnit, "timeUnit").toMillis(tolerance));
     }
 
     /**


### PR DESCRIPTION
## Description
Added overloaded constructor with an additional TimeUnit field which would convert the given tolerance to milli seconds

## Motivation and Context
https://github.com/alexa/alexa-skills-kit-sdk-for-java/issues/173

## Testing
Modified the test class to run with Parameterized.class to run all the existing test cases for the newly added constructor.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

[issues]: https://github.com/alexa/alexa-skills-kit-sdk-for-java/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement

