### PR TITLE
Expose raw request JSON through HandlerInput

### DIFF
--- a/ask-sdk-core/src/com/amazon/ask/CustomSkill.java
+++ b/ask-sdk-core/src/com/amazon/ask/CustomSkill.java
@@ -2,8 +2,10 @@ package com.amazon.ask;
 
 import com.amazon.ask.impl.AbstractSkill;
 import com.amazon.ask.model.services.Serializer;
+import com.amazon.ask.request.UnmarshalledRequest;
 import com.amazon.ask.request.dispatcher.GenericRequestDispatcher;
 import com.amazon.ask.request.dispatcher.impl.BaseRequestDispatcher;
+import com.amazon.ask.request.impl.BaseUnmarshalledRequest;
 import com.amazon.ask.util.JacksonSerializer;
 import com.amazon.ask.util.impl.JacksonJsonMarshaller;
 import com.amazon.ask.util.impl.JacksonJsonUnmarshaller;
@@ -20,6 +22,7 @@ import com.amazon.ask.model.services.DefaultApiConfiguration;
 import com.amazon.ask.model.services.ServiceClientFactory;
 import com.amazon.ask.util.SdkConstants;
 import com.amazon.ask.util.UserAgentUtils;
+import com.fasterxml.jackson.databind.JsonNode;
 
 import java.util.Optional;
 
@@ -53,13 +56,21 @@ public class CustomSkill extends AbstractSkill<RequestEnvelope, ResponseEnvelope
         return invoke(requestEnvelope, null);
     }
 
+    public ResponseEnvelope invoke(RequestEnvelope requestEnvelope, Object context) {
+        return invoke(new BaseUnmarshalledRequest<>(requestEnvelope, null), context);
+    }
+
     /**
      * Invokes the dispatcher to handler the request envelope and construct the handler input
-     * @param requestEnvelope request envelope
+     * @param unmarshalledRequest unmarshalled output from {@link JacksonJsonUnmarshaller}, containing a
+     *                            {@link RequestEnvelope} and a JSON representation of the request.
      * @param context context
      * @return optional request envelope
      */
-    public ResponseEnvelope invoke(RequestEnvelope requestEnvelope, Object context) {
+    protected ResponseEnvelope invoke(UnmarshalledRequest<RequestEnvelope> unmarshalledRequest, Object context) {
+        RequestEnvelope requestEnvelope = unmarshalledRequest.getUnmarshalledRequest();
+        JsonNode requestEnvelopeJson = unmarshalledRequest.getRequestJson();
+
         if (skillId != null && !requestEnvelope.getContext().getSystem().getApplication().getApplicationId().equals(skillId)) {
             throw new AskSdkException("AlexaSkill ID verification failed.");
         }
@@ -73,6 +84,7 @@ public class CustomSkill extends AbstractSkill<RequestEnvelope, ResponseEnvelope
                 .withPersistenceAdapter(persistenceAdapter)
                 .withContext(context)
                 .withServiceClientFactory(factory)
+                .withRequestEnvelopeJson(requestEnvelopeJson)
                 .build();
 
         Optional<Response> response = requestDispatcher.dispatch(handlerInput);

--- a/ask-sdk-core/src/com/amazon/ask/dispatcher/request/handler/HandlerInput.java
+++ b/ask-sdk-core/src/com/amazon/ask/dispatcher/request/handler/HandlerInput.java
@@ -20,6 +20,8 @@ import com.amazon.ask.model.Request;
 import com.amazon.ask.model.RequestEnvelope;
 import com.amazon.ask.model.services.ServiceClientFactory;
 import com.amazon.ask.response.ResponseBuilder;
+import com.amazon.ask.util.ValidationUtils;
+import com.fasterxml.jackson.databind.JsonNode;
 
 import java.util.function.Predicate;
 
@@ -37,10 +39,11 @@ public class HandlerInput extends AbstractHandlerInput<Request> {
     protected final AttributesManager attributesManager;
     protected final ServiceClientFactory serviceClientFactory;
     protected final ResponseBuilder responseBuilder;
+    protected final JsonNode requestEnvelopeJson;
 
     protected HandlerInput(RequestEnvelope requestEnvelope, PersistenceAdapter persistenceAdapter,
-                           Object context, ServiceClientFactory serviceClientFactory) {
-        super(requestEnvelope.getRequest(), context);
+                           Object context, ServiceClientFactory serviceClientFactory, JsonNode requestEnvelopeJson) {
+        super(ValidationUtils.assertNotNull(requestEnvelope, "request envelope").getRequest(), context);
         this.requestEnvelope = requestEnvelope;
         this.serviceClientFactory = serviceClientFactory;
         this.attributesManager = AttributesManager.builder()
@@ -48,6 +51,7 @@ public class HandlerInput extends AbstractHandlerInput<Request> {
                 .withPersistenceAdapter(persistenceAdapter)
                 .build();
         this.responseBuilder = new ResponseBuilder();
+        this.requestEnvelopeJson = requestEnvelopeJson;
     }
 
     public static Builder builder() {
@@ -71,6 +75,13 @@ public class HandlerInput extends AbstractHandlerInput<Request> {
     public AttributesManager getAttributesManager() {
         return attributesManager;
     }
+
+    /**
+     * Returns a {@link JsonNode} representation of the incoming Request Envelope.
+     *
+     * @return JSON request envelope representation
+     */
+    public JsonNode getRequestEnvelopeJson() { return requestEnvelopeJson; }
 
     /**
      * Returns a {@link ServiceClientFactory} used to retrieve service client instances that can call Alexa APIs.
@@ -108,6 +119,7 @@ public class HandlerInput extends AbstractHandlerInput<Request> {
         private RequestEnvelope requestEnvelope;
         private PersistenceAdapter persistenceAdapter;
         private ServiceClientFactory serviceClientFactory;
+        private JsonNode requestEnvelopeJson;
 
         private Builder() {
         }
@@ -127,8 +139,13 @@ public class HandlerInput extends AbstractHandlerInput<Request> {
             return this;
         }
 
+        public Builder withRequestEnvelopeJson(JsonNode requestEnvelopeJson) {
+            this.requestEnvelopeJson = requestEnvelopeJson;
+            return this;
+        }
+
         public HandlerInput build() {
-            return new HandlerInput(requestEnvelope, persistenceAdapter, context, serviceClientFactory);
+            return new HandlerInput(requestEnvelope, persistenceAdapter, context, serviceClientFactory, requestEnvelopeJson);
         }
     }
 

--- a/ask-sdk-core/src/com/amazon/ask/dispatcher/request/handler/HandlerInput.java
+++ b/ask-sdk-core/src/com/amazon/ask/dispatcher/request/handler/HandlerInput.java
@@ -20,6 +20,8 @@ import com.amazon.ask.model.Request;
 import com.amazon.ask.model.RequestEnvelope;
 import com.amazon.ask.model.services.ServiceClientFactory;
 import com.amazon.ask.response.ResponseBuilder;
+import com.amazon.ask.util.ValidationUtils;
+import com.fasterxml.jackson.databind.JsonNode;
 
 import java.util.function.Predicate;
 
@@ -37,10 +39,11 @@ public class HandlerInput extends AbstractHandlerInput<Request> {
     protected final AttributesManager attributesManager;
     protected final ServiceClientFactory serviceClientFactory;
     protected final ResponseBuilder responseBuilder;
+    protected final JsonNode requestEnvelopeJson;
 
     protected HandlerInput(RequestEnvelope requestEnvelope, PersistenceAdapter persistenceAdapter,
-                           Object context, ServiceClientFactory serviceClientFactory) {
-        super(requestEnvelope.getRequest(), context);
+                           Object context, ServiceClientFactory serviceClientFactory, JsonNode requestEnvelopeJson) {
+        super(ValidationUtils.assertNotNull(requestEnvelope, "request envelope").getRequest(), context);
         this.requestEnvelope = requestEnvelope;
         this.serviceClientFactory = serviceClientFactory;
         this.attributesManager = AttributesManager.builder()
@@ -48,6 +51,7 @@ public class HandlerInput extends AbstractHandlerInput<Request> {
                 .withPersistenceAdapter(persistenceAdapter)
                 .build();
         this.responseBuilder = new ResponseBuilder();
+        this.requestEnvelopeJson = requestEnvelopeJson;
     }
 
     public static Builder builder() {
@@ -71,6 +75,12 @@ public class HandlerInput extends AbstractHandlerInput<Request> {
     public AttributesManager getAttributesManager() {
         return attributesManager;
     }
+
+    /**
+     *
+     * @return
+     */
+    public JsonNode getRequestEnvelopeJson() { return requestEnvelopeJson; }
 
     /**
      * Returns a {@link ServiceClientFactory} used to retrieve service client instances that can call Alexa APIs.
@@ -108,6 +118,7 @@ public class HandlerInput extends AbstractHandlerInput<Request> {
         private RequestEnvelope requestEnvelope;
         private PersistenceAdapter persistenceAdapter;
         private ServiceClientFactory serviceClientFactory;
+        private JsonNode requestEnvelopeJson;
 
         private Builder() {
         }
@@ -127,8 +138,13 @@ public class HandlerInput extends AbstractHandlerInput<Request> {
             return this;
         }
 
+        public Builder withRequestEnvelopeJson(JsonNode requestEnvelopeJson) {
+            this.requestEnvelopeJson = requestEnvelopeJson;
+            return this;
+        }
+
         public HandlerInput build() {
-            return new HandlerInput(requestEnvelope, persistenceAdapter, context, serviceClientFactory);
+            return new HandlerInput(requestEnvelope, persistenceAdapter, context, serviceClientFactory, requestEnvelopeJson);
         }
     }
 

--- a/ask-sdk-runtime/src/com/amazon/ask/impl/AbstractSkill.java
+++ b/ask-sdk-runtime/src/com/amazon/ask/impl/AbstractSkill.java
@@ -15,6 +15,7 @@ package com.amazon.ask.impl;
 
 import com.amazon.ask.AlexaSkill;
 import com.amazon.ask.request.SkillRequest;
+import com.amazon.ask.request.UnmarshalledRequest;
 import com.amazon.ask.response.SkillResponse;
 import com.amazon.ask.response.impl.BaseSkillResponse;
 import com.amazon.ask.util.JsonMarshaller;
@@ -41,7 +42,7 @@ public abstract class AbstractSkill<Request, Response> implements AlexaSkill<Req
 
     @Override
     public SkillResponse<Response> execute(SkillRequest request, Object context) {
-        Optional<Request> deserializedRequest = unmarshaller.unmarshall(request.getRawRequest());
+        Optional<UnmarshalledRequest<Request>> deserializedRequest = unmarshaller.unmarshall(request.getRawRequest());
         if (!deserializedRequest.isPresent()) {
             return null;
         }
@@ -49,6 +50,6 @@ public abstract class AbstractSkill<Request, Response> implements AlexaSkill<Req
         return new BaseSkillResponse<>(marshaller, response);
     }
 
-    protected abstract Response invoke(Request request, Object context);
+    protected abstract Response invoke(UnmarshalledRequest<Request> unmarshalledRequest, Object context);
 
 }

--- a/ask-sdk-runtime/src/com/amazon/ask/request/UnmarshalledRequest.java
+++ b/ask-sdk-runtime/src/com/amazon/ask/request/UnmarshalledRequest.java
@@ -11,19 +11,26 @@
     the specific language governing permissions and limitations under the License.
  */
 
-package com.amazon.ask.util;
+package com.amazon.ask.request;
 
-import com.amazon.ask.request.UnmarshalledRequest;
-
-import java.util.Optional;
+import com.fasterxml.jackson.databind.JsonNode;
 
 /**
- * Unmarshalls a given type from JSON.
- *
- * @param <Type> type to unmarshall
+ * Output from a {@link com.amazon.ask.util.JsonUnmarshaller}.
+ * @param <Type> unmarshalled type
  */
-public interface JsonUnmarshaller<Type> {
+public interface UnmarshalledRequest<Type> {
 
-    Optional<UnmarshalledRequest<Type>> unmarshall(byte[] in);
+    /**
+     * Returns the unmarshalled request
+     * @return unmarshalled request
+     */
+    Type getUnmarshalledRequest();
+
+    /**
+     * Returns the raw request as a {@link JsonNode}
+     * @return JSON representation of request
+     */
+    JsonNode getRequestJson();
 
 }

--- a/ask-sdk-runtime/src/com/amazon/ask/request/UnmarshalledRequest.java
+++ b/ask-sdk-runtime/src/com/amazon/ask/request/UnmarshalledRequest.java
@@ -1,0 +1,36 @@
+/*
+    Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+    Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file
+    except in compliance with the License. A copy of the License is located at
+
+        http://aws.amazon.com/apache2.0/
+
+    or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for
+    the specific language governing permissions and limitations under the License.
+ */
+
+package com.amazon.ask.request;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+/**
+ * Output from a {@link com.amazon.ask.util.JsonUnmarshaller}.
+ * @param <Type> unmarshalled type
+ */
+public interface UnmarshalledRequest<Type> {
+
+    /**
+     * Returns the unmarshalled request
+     * @return unmarshalled request
+     */
+    Type getUnmarshalledRequest();
+
+    /**
+     * Returns the raw request as a {@link JsonNode}
+     * @return JSON representation of request
+     */
+    JsonNode getRequestJson();
+
+}

--- a/ask-sdk-runtime/src/com/amazon/ask/request/impl/BaseUnmarshalledRequest.java
+++ b/ask-sdk-runtime/src/com/amazon/ask/request/impl/BaseUnmarshalledRequest.java
@@ -1,0 +1,44 @@
+/*
+    Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+    Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file
+    except in compliance with the License. A copy of the License is located at
+
+        http://aws.amazon.com/apache2.0/
+
+    or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for
+    the specific language governing permissions and limitations under the License.
+ */
+
+package com.amazon.ask.request.impl;
+
+import com.amazon.ask.request.UnmarshalledRequest;
+import com.amazon.ask.util.ValidationUtils;
+import com.fasterxml.jackson.databind.JsonNode;
+
+/**
+ * Default implementation of an {@link UnmarshalledRequest}
+ * @param <Type> unmarshalled type
+ */
+public class BaseUnmarshalledRequest<Type> implements UnmarshalledRequest<Type> {
+
+    private final Type unmarshalledRequest;
+    private final JsonNode json;
+
+    public BaseUnmarshalledRequest(Type unmarshalledRequest, JsonNode json) {
+        this.unmarshalledRequest = ValidationUtils.assertNotNull(unmarshalledRequest, "unmarshalled request");
+        this.json = json;
+    }
+
+    @Override
+    public Type getUnmarshalledRequest() {
+        return unmarshalledRequest;
+    }
+
+    @Override
+    public JsonNode getRequestJson() {
+        return json;
+    }
+
+}

--- a/ask-sdk-runtime/src/com/amazon/ask/request/impl/BaseUnmarshalledRequest.java
+++ b/ask-sdk-runtime/src/com/amazon/ask/request/impl/BaseUnmarshalledRequest.java
@@ -1,0 +1,44 @@
+/*
+    Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+    Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file
+    except in compliance with the License. A copy of the License is located at
+
+        http://aws.amazon.com/apache2.0/
+
+    or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for
+    the specific language governing permissions and limitations under the License.
+ */
+
+package com.amazon.ask.request.impl;
+
+import com.amazon.ask.request.UnmarshalledRequest;
+import com.amazon.ask.util.ValidationUtils;
+import com.fasterxml.jackson.databind.JsonNode;
+
+/**
+ * Default implementation of an {@link UnmarshalledRequest}
+ * @param <Type> unmarshalled type
+ */
+public class BaseUnmarshalledRequest<Type> implements UnmarshalledRequest<Type> {
+
+    private final Type unmarshalledRequest;
+    private final JsonNode json;
+
+    public BaseUnmarshalledRequest(Type unmarshalledRequest, JsonNode json) {
+        this.unmarshalledRequest = ValidationUtils.assertNotNull(unmarshalledRequest, "unmarshalled request");
+        this.json = json;
+    }
+
+    @Override
+    public Type getUnmarshalledRequest() {
+        return unmarshalledRequest;
+    }
+
+    @Override
+    public JsonNode getRequestJson() {
+        return json;
+    }
+
+}

--- a/ask-sdk-runtime/src/com/amazon/ask/util/JsonUnmarshaller.java
+++ b/ask-sdk-runtime/src/com/amazon/ask/util/JsonUnmarshaller.java
@@ -13,6 +13,8 @@
 
 package com.amazon.ask.util;
 
+import com.amazon.ask.request.UnmarshalledRequest;
+
 import java.util.Optional;
 
 /**
@@ -22,6 +24,6 @@ import java.util.Optional;
  */
 public interface JsonUnmarshaller<Type> {
 
-    Optional<Type> unmarshall(byte[] in);
+    Optional<UnmarshalledRequest<Type>> unmarshall(byte[] in);
 
 }

--- a/ask-sdk-runtime/src/com/amazon/ask/util/impl/JacksonJsonUnmarshaller.java
+++ b/ask-sdk-runtime/src/com/amazon/ask/util/impl/JacksonJsonUnmarshaller.java
@@ -14,6 +14,8 @@
 package com.amazon.ask.util.impl;
 
 import com.amazon.ask.exception.AskSdkException;
+import com.amazon.ask.request.UnmarshalledRequest;
+import com.amazon.ask.request.impl.BaseUnmarshalledRequest;
 import com.amazon.ask.util.JsonUnmarshaller;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -39,13 +41,14 @@ public class JacksonJsonUnmarshaller<Type> implements JsonUnmarshaller<Type> {
     }
 
     @Override
-    public Optional<Type> unmarshall(byte[] in) {
+    public Optional<UnmarshalledRequest<Type>> unmarshall(byte[] in) {
         try {
             JsonNode json = MAPPER.readTree(in);
             if (!json.has(requiredField)) {
                 return Optional.empty();
             }
-            return Optional.of(MAPPER.treeToValue(json, outputType));
+            UnmarshalledRequest<Type> unmarshalledRequest = new BaseUnmarshalledRequest<>(MAPPER.treeToValue(json, outputType), json);
+            return Optional.of(unmarshalledRequest);
         } catch (IOException e) {
             throw new AskSdkException("Deserialization error", e);
         }

--- a/ask-sdk-runtime/tst/com/amazon/ask/util/impl/JacksonJsonUnmarshallerTest.java
+++ b/ask-sdk-runtime/tst/com/amazon/ask/util/impl/JacksonJsonUnmarshallerTest.java
@@ -1,0 +1,71 @@
+package com.amazon.ask.util.impl;
+
+import com.amazon.ask.exception.AskSdkException;
+import com.amazon.ask.request.UnmarshalledRequest;
+import com.amazon.ask.util.JsonUnmarshaller;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Optional;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class JacksonJsonUnmarshallerTest {
+
+    private JsonUnmarshaller<FooType> jsonUnmarshaller;
+
+    @Before
+    public void setUp() {
+        jsonUnmarshaller = new JacksonJsonUnmarshaller<>(FooType.class, "validField");
+    }
+
+    @Test
+    public void required_field_missing_returns_optional_empty() {
+        assertEquals(jsonUnmarshaller.unmarshall(getPayload("invalidField")), Optional.empty());
+    }
+
+    @Test
+    public void required_field_present_returns_unmarshalled_type() {
+        Optional<UnmarshalledRequest<FooType>> unmarshalledRequest = jsonUnmarshaller.unmarshall(getPayload("validField"));
+        assertTrue(unmarshalledRequest.isPresent());
+    }
+
+    @Test
+    public void unmarshalled_instance_correct() {
+        Optional<UnmarshalledRequest<FooType>> unmarshalledRequest = jsonUnmarshaller.unmarshall(getPayload("validField"));
+        FooType fooType = unmarshalledRequest.get().getUnmarshalledRequest();
+        assertEquals(fooType.getValidField(), "foo");
+    }
+
+    @Test
+    public void unmarshalled_json_correct() {
+        Optional<UnmarshalledRequest<FooType>> unmarshalledRequest = jsonUnmarshaller.unmarshall(getPayload("validField"));
+        JsonNode json = unmarshalledRequest.get().getRequestJson();
+        assertEquals(json.get("validField").asText(), "foo");
+    }
+
+    @Test(expected = AskSdkException.class)
+    public void unmarshaller_exception_wrapped_in_sdk_exception() {
+        jsonUnmarshaller.unmarshall("{foo}".getBytes());
+    }
+
+    private byte[] getPayload(String fieldName) {
+        String payload = String.format("{\"%s\":\"foo\"}", fieldName);
+        return payload.getBytes();
+    }
+
+    private static class FooType {
+        private String validField;
+
+        public String getValidField() {
+            return validField;
+        }
+
+        public void setValidField(String validField) {
+            this.validField = validField;
+        }
+    }
+
+}


### PR DESCRIPTION
## Description
Exposes a ``JsonNode`` representation of the incoming request through the HandlerInput. This allows users to interact with the JSON directly, useful for utility logic or when certain request properties are not yet modeled.

## Motivation and Context
A number of customers have requested the ability to interact directly with the incoming request JSON. This change exposes that capability.

## Testing
New unit tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

[issues]: https://github.com/alexa/alexa-skills-kit-sdk-for-java/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement

