### PR TITLE
Bug fix: pass Lambda context into skill invocation call

### DIFF
--- a/ask-sdk-lambda-support/src/com/amazon/ask/SkillStreamHandler.java
+++ b/ask-sdk-lambda-support/src/com/amazon/ask/SkillStreamHandler.java
@@ -68,7 +68,7 @@ public abstract class SkillStreamHandler implements RequestStreamHandler {
     public final void handleRequest(InputStream input, OutputStream output, Context context) throws IOException {
         byte[] inputBytes = IOUtils.toByteArray(input);
         for (AlexaSkill skill : skills) {
-            SkillResponse response = skill.execute(new BaseSkillRequest(inputBytes));
+            SkillResponse response = skill.execute(new BaseSkillRequest(inputBytes), context);
             if (response != null) {
                 if (response.isPresent()) {
                     response.writeTo(output);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes #198. This regression was introduced when the runtime layer was added to the SDK. At that point, the Lambda context was no longer passed in to the SDK invocation call, meaning any subsequent calls to retrieve it in customer code would result in NPEs.

## Testing
Tested with sample skill and new unit test.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/alexa/alexa-skills-kit-sdk-for-java/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement

