### PR TITLE
provide default implementation for template resolvers

### DIFF
--- a/ask-sdk-core/src/com/amazon/ask/module/SdkModuleContext.java
+++ b/ask-sdk-core/src/com/amazon/ask/module/SdkModuleContext.java
@@ -24,6 +24,7 @@ import com.amazon.ask.request.handler.adapter.GenericHandlerAdapter;
 import com.amazon.ask.request.interceptor.GenericRequestInterceptor;
 import com.amazon.ask.request.interceptor.GenericResponseInterceptor;
 import com.amazon.ask.request.mapper.GenericRequestMapper;
+import com.amazon.ask.response.template.TemplateFactory;
 
 import java.util.Collections;
 import java.util.List;
@@ -113,6 +114,15 @@ public class SdkModuleContext {
                     "module attempting to override previously set value.");
         }
         skillConfigBuilder.withApiClient(apiClient);
+        return this;
+    }
+
+    public SdkModuleContext setTemplateFactory(TemplateFactory templateFactory) {
+        if (skillConfigBuilder.getTemplateFactory() != null) {
+            throw new AskSdkException("Conflicting Template factory configuration: " +
+                    "module attempting to override previously set value.");
+        }
+        skillConfigBuilder.withTemplateFactory(templateFactory);
         return this;
     }
 

--- a/ask-sdk/pom.xml
+++ b/ask-sdk/pom.xml
@@ -60,6 +60,11 @@
       <version>2.17.2</version>
     </dependency>
     <dependency>
+      <groupId>com.amazon.alexa</groupId>
+      <artifactId>ask-sdk-freemarker</artifactId>
+      <version>2.17.2</version>
+    </dependency>
+    <dependency>
       <groupId>org.powermock</groupId>
       <artifactId>powermock-api-mockito</artifactId>
       <version>1.7.3</version>

--- a/ask-sdk/src/com/amazon/ask/builder/StandardSkillBuilder.java
+++ b/ask-sdk/src/com/amazon/ask/builder/StandardSkillBuilder.java
@@ -55,6 +55,11 @@ public class StandardSkillBuilder extends SkillBuilder<StandardSkillBuilder> {
         return this;
     }
 
+    public StandardSkillBuilder withTemplateDirectoryPath(String templateDirectoryPath) {
+        standardSdkModuleBuilder.withTemplateDirectoryPath(templateDirectoryPath);
+        return this;
+    }
+
     protected SkillConfiguration.Builder getConfigBuilder() {
         registerSdkModule(standardSdkModuleBuilder.build());
         return super.getConfigBuilder();

--- a/ask-sdk/tst/com/amazon/ask/builder/StandardSkillBuilderTest.java
+++ b/ask-sdk/tst/com/amazon/ask/builder/StandardSkillBuilderTest.java
@@ -26,6 +26,7 @@ import com.amazon.ask.request.exception.mapper.GenericExceptionMapper;
 import com.amazon.ask.request.handler.adapter.impl.BaseHandlerAdapter;
 import com.amazon.ask.request.mapper.GenericRequestMapper;
 import com.amazon.ask.request.mapper.impl.BaseRequestMapper;
+import com.amazon.ask.response.template.TemplateFactory;
 import com.amazon.ask.services.ApacheHttpApiClient;
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
 import org.junit.Before;
@@ -36,6 +37,7 @@ import java.util.Optional;
 import static junit.framework.TestCase.assertNull;
 import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -103,6 +105,21 @@ public class StandardSkillBuilderTest {
         builder.addRequestHandler(mockRequestHandler);
         SkillConfiguration configuration = builder.getConfigBuilder().build();
         assertTrue(configuration.getApiClient() instanceof ApacheHttpApiClient);
+    }
+
+    @Test
+    public void template_factory_not_used_if_template_directory_path_not_provided() {
+        builder.addRequestHandler(mockRequestHandler);
+        SkillConfiguration configuration = builder.getConfigBuilder().build();
+        assertNull(configuration.getTemplateFactory());
+    }
+
+    @Test
+    public void template_factory_is_used_if_template_directory_path_is_provided() {
+        builder.addRequestHandler(mockRequestHandler);
+        SkillConfiguration configuration = builder.withTemplateDirectoryPath("path").getConfigBuilder().build();
+        assertNotNull(configuration.getTemplateFactory());
+        assertTrue(configuration.getTemplateFactory() instanceof TemplateFactory);
     }
 
     private HandlerInput getInputForIntent(String intentName) {

--- a/docs/en/Response-Building.rst
+++ b/docs/en/Response-Building.rst
@@ -106,12 +106,26 @@ To use the ``FreeMarkerTemplateRenderer``, you must add a dependency on ``ask-sd
       <version>${version}</version>
     </dependency>
 
-Example Usage of the Template Factory
+Example Usage of Template Factory
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The following example shows how to configure the ``BaseTemplateFactory`` using the default ``LocalTemplateFileLoader`` and ``ConcurrentLRUTemplateCache`` to construct a skill response with a FreeMarker template.
+The following example shows the basic setup of Template Factory. Skill Developer provides just the root path of the templates and the SDK would generate a default implementation of Template Factory.
 
-**Configure Template Factory with Template Loader and Template Renderer to Skill Builder**
+.. code:: java
+
+    private static Skill getSkill() {
+
+        // Build Skill
+        return Skills.standard()
+                .withTemplateDirectoryPath("/com/amazon/ask/example/")
+                .addRequestHandlers(
+                        new LaunchRequestHandler(),
+                        ... ...
+                        new SessionEndedRequestHandler())
+                .build();
+    }
+
+Alternatively, a Skill Developer can provide a custom implementation of Template Factory.
 
 .. code:: java
 
@@ -138,6 +152,29 @@ The following example shows how to configure the ``BaseTemplateFactory`` using t
 
         // Build Skill
         return Skills.standard()
+                .withTemplateFactory(templateFactory)
+                .addRequestHandlers(
+                        new LaunchRequestHandler(),
+                        ... ...
+                        new SessionEndedRequestHandler())
+                .build();
+    }
+
+If the Skill Developer provides both the templates' directory path and a custom Template Factory object, an exception is thrown.
+
+.. code:: java
+
+    private static Skill getSkill() {
+
+        // Build loader and renderer and pass it to Template Factory.
+        TemplateFactory templateFactory = BaseTemplateFactory.builder()
+                .withTemplateRenderer(renderer)
+                .addTemplateLoader(loader)
+                .build();
+
+        // throws exception.
+        return Skills.standard()
+                .withTemplateDirectoryPath("/com/amazon/ask/example/")
                 .withTemplateFactory(templateFactory)
                 .addRequestHandlers(
                         new LaunchRequestHandler(),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR provides a default implementation where the customer has to provide the templates' directory path and we'd create the Template factory with default implementations of Template loader, renderer and Unmarshaller. If the user provides both templates' directory path and a template factory, it'd throw an exception.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit test cases.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/alexa/alexa-skills-kit-sdk-for-java/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement

