### PR TITLE
Add response interceptor method for returning modified response

### DIFF
--- a/ask-sdk-core/tst/com/amazon/ask/dispatcher/DefaultRequestDispatcherTest.java
+++ b/ask-sdk-core/tst/com/amazon/ask/dispatcher/DefaultRequestDispatcherTest.java
@@ -237,11 +237,12 @@ public class DefaultRequestDispatcherTest {
         ResponseInterceptor chainInterceptor = mock(ResponseInterceptor.class);
         responseInterceptors.add(globalInterceptor);
         doReturn(Collections.singletonList(chainInterceptor)).when(mockHandlerChain).getResponseInterceptors();
+        when(chainInterceptor.processResponse(handlerInput, Optional.of(mockResponse))).thenReturn(Optional.of(mockResponse));
         dispatcher.dispatch(handlerInput);
         InOrder inOrder = inOrder(globalInterceptor, chainInterceptor, mockAdapter);
         inOrder.verify(mockAdapter).execute(any(), any());
-        inOrder.verify(chainInterceptor).process(handlerInput, Optional.of(mockResponse));
-        inOrder.verify(globalInterceptor).process(handlerInput, Optional.of(mockResponse));
+        inOrder.verify(chainInterceptor).processResponse(handlerInput, Optional.of(mockResponse));
+        inOrder.verify(globalInterceptor).processResponse(handlerInput, Optional.of(mockResponse));
     }
 
     @Test
@@ -401,7 +402,7 @@ public class DefaultRequestDispatcherTest {
         doReturn(Collections.singletonList(chainResponseInterceptor)).when(mockHandlerChain).getResponseInterceptors();
 
         Exception e = new IllegalStateException();
-        doThrow(e).when(chainResponseInterceptor).process(any(), any());
+        doThrow(e).when(chainResponseInterceptor).processResponse(any(), any());
         when(mockExceptionMapper.getHandler(any(), any())).thenReturn(Optional.empty());
         try {
             dispatcher.dispatch(handlerInput);
@@ -409,8 +410,8 @@ public class DefaultRequestDispatcherTest {
         } catch (UnhandledSkillException ex) {
             verify(globalRequestInterceptor).process(handlerInput);
             verify(chainRequestInterceptor).process(handlerInput);
-            verify(chainResponseInterceptor).process(handlerInput, Optional.of(mockResponse));
-            verify(globalResponseInterceptor, never()).process(handlerInput, Optional.of(mockResponse));
+            verify(chainResponseInterceptor).processResponse(handlerInput, Optional.of(mockResponse));
+            verify(globalResponseInterceptor, never()).processResponse(handlerInput, Optional.of(mockResponse));
             verify(mockMapper).getRequestHandlerChain(any());
             verify(mockAdapter).supports(any());
             verify(mockAdapter).execute(any(), any());
@@ -428,9 +429,10 @@ public class DefaultRequestDispatcherTest {
         ResponseInterceptor chainResponseInterceptor = mock(ResponseInterceptor.class);
         responseInterceptors.add(globalResponseInterceptor);
         doReturn(Collections.singletonList(chainResponseInterceptor)).when(mockHandlerChain).getResponseInterceptors();
+        when(chainResponseInterceptor.processResponse(handlerInput, Optional.of(mockResponse))).thenReturn(Optional.of(mockResponse));
 
         Exception e = new IllegalStateException();
-        doThrow(e).when(globalResponseInterceptor).process(any(), any());
+        doThrow(e).when(globalResponseInterceptor).processResponse(any(), any());
         when(mockExceptionMapper.getHandler(any(), any())).thenReturn(Optional.empty());
         try {
             dispatcher.dispatch(handlerInput);
@@ -438,8 +440,8 @@ public class DefaultRequestDispatcherTest {
         } catch (UnhandledSkillException ex) {
             verify(globalRequestInterceptor).process(handlerInput);
             verify(chainRequestInterceptor).process(handlerInput);
-            verify(chainResponseInterceptor).process(handlerInput, Optional.of(mockResponse));
-            verify(globalResponseInterceptor).process(handlerInput, Optional.of(mockResponse));
+            verify(chainResponseInterceptor).processResponse(handlerInput, Optional.of(mockResponse));
+            verify(globalResponseInterceptor).processResponse(handlerInput, Optional.of(mockResponse));
             verify(mockMapper).getRequestHandlerChain(any());
             verify(mockAdapter).supports(any());
             verify(mockAdapter).execute(any(), any());

--- a/ask-sdk-runtime/src/com/amazon/ask/request/dispatcher/impl/BaseRequestDispatcher.java
+++ b/ask-sdk-runtime/src/com/amazon/ask/request/dispatcher/impl/BaseRequestDispatcher.java
@@ -133,7 +133,7 @@ public class BaseRequestDispatcher<Input, Output> implements GenericRequestDispa
 
             // execute any response interceptors attached to the handler chain
             for (GenericResponseInterceptor<Input, Output> responseInterceptor : handlerChain.get().getResponseInterceptors()) {
-                responseInterceptor.process(input, response);
+                response = responseInterceptor.processResponse(input, response);
             }
         } catch (Exception e) {
             return handlerChain.get().getExceptionHandlers().stream()
@@ -144,7 +144,7 @@ public class BaseRequestDispatcher<Input, Output> implements GenericRequestDispa
 
         // execute any global response interceptors
         for (GenericResponseInterceptor<Input, Output> responseInterceptor : responseInterceptors) {
-            responseInterceptor.process(input, response);
+            response = responseInterceptor.processResponse(input, response);
         }
 
         return response;

--- a/ask-sdk-runtime/src/com/amazon/ask/request/interceptor/GenericResponseInterceptor.java
+++ b/ask-sdk-runtime/src/com/amazon/ask/request/interceptor/GenericResponseInterceptor.java
@@ -29,6 +29,18 @@ public interface GenericResponseInterceptor<Input, Output> {
      * @param input handler input
      * @param response handler output
      */
-    void process(Input input, Output response);
+    default void process(Input input, Output response) {}
+
+    /**
+     * Intercept the output from the request handler after it is executed and return an updated response.
+     *
+     * @param input handler input
+     * @param response handler output
+     * @return updated response
+     */
+    default Output processResponse(Input input, Output response) {
+        process(input, response);
+        return response;
+    }
 
 }

--- a/ask-sdk-runtime/tst/com/amazon/ask/request/dispatcher/BaseRequestDispatcherTest.java
+++ b/ask-sdk-runtime/tst/com/amazon/ask/request/dispatcher/BaseRequestDispatcherTest.java
@@ -283,11 +283,13 @@ public class BaseRequestDispatcherTest {
         GenericResponseInterceptor chainInterceptor = mock(GenericResponseInterceptor.class);
         responseInterceptors.add(globalInterceptor);
         when(mockHandlerChain.getResponseInterceptors()).thenReturn(Collections.singletonList(chainInterceptor));
+        when(globalInterceptor.processResponse(mockInput, mockOutput)).thenReturn(mockOutput);
+        when(chainInterceptor.processResponse(mockInput, mockOutput)).thenReturn(mockOutput);
         dispatcher.dispatch(mockInput);
         InOrder inOrder = inOrder(globalInterceptor, chainInterceptor, mockAdapter);
         inOrder.verify(mockAdapter).execute(any(), any());
-        inOrder.verify(chainInterceptor).process(mockInput, mockOutput);
-        inOrder.verify(globalInterceptor).process(mockInput, mockOutput);
+        inOrder.verify(chainInterceptor).processResponse(mockInput, mockOutput);
+        inOrder.verify(globalInterceptor).processResponse(mockInput, mockOutput);
     }
 
     @Test
@@ -310,8 +312,8 @@ public class BaseRequestDispatcherTest {
         } catch (AskSdkException ex) {
             verify(globalRequestInterceptor).process(mockInput);
             verify(chainRequestInterceptor, never()).process(mockInput);
-            verify(chainResponseInterceptor, never()).process(mockInput, mockOutput);
-            verify(globalResponseInterceptor, never()).process(mockInput, mockOutput);
+            verify(chainResponseInterceptor, never()).processResponse(mockInput, mockOutput);
+            verify(globalResponseInterceptor, never()).processResponse(mockInput, mockOutput);
             verify(mockMapper).getRequestHandlerChain(any());
             verify(mockAdapter, never()).supports(any());
             verify(mockAdapter, never()).execute(any(), any());
@@ -338,8 +340,8 @@ public class BaseRequestDispatcherTest {
         } catch (AskSdkException ex) {
             verify(globalRequestInterceptor).process(mockInput);
             verify(chainRequestInterceptor, never()).process(mockInput);
-            verify(chainResponseInterceptor, never()).process(mockInput, mockOutput);
-            verify(globalResponseInterceptor, never()).process(mockInput, mockOutput);
+            verify(chainResponseInterceptor, never()).processResponse(mockInput, mockOutput);
+            verify(globalResponseInterceptor, never()).processResponse(mockInput, mockOutput);
             verify(mockMapper).getRequestHandlerChain(any());
             verify(mockAdapter).supports(any());
             verify(mockAdapter, never()).execute(any(), any());
@@ -367,8 +369,8 @@ public class BaseRequestDispatcherTest {
         } catch (AskSdkException ex) {
             verify(globalRequestInterceptor).process(mockInput);
             verify(chainRequestInterceptor, never()).process(mockInput);
-            verify(chainResponseInterceptor, never()).process(mockInput, mockOutput);
-            verify(globalResponseInterceptor, never()).process(mockInput, mockOutput);
+            verify(chainResponseInterceptor, never()).processResponse(mockInput, mockOutput);
+            verify(globalResponseInterceptor, never()).processResponse(mockInput, mockOutput);
             verify(mockMapper, never()).getRequestHandlerChain(any());
             verify(mockAdapter, never()).supports(any());
             verify(mockAdapter, never()).execute(any(), any());
@@ -398,8 +400,8 @@ public class BaseRequestDispatcherTest {
         } catch (AskSdkException ex) {
             verify(globalRequestInterceptor).process(mockInput);
             verify(chainRequestInterceptor).process(mockInput);
-            verify(chainResponseInterceptor, never()).process(mockInput, mockOutput);
-            verify(globalResponseInterceptor, never()).process(mockInput, mockOutput);
+            verify(chainResponseInterceptor, never()).processResponse(mockInput, mockOutput);
+            verify(globalResponseInterceptor, never()).processResponse(mockInput, mockOutput);
             verify(mockMapper).getRequestHandlerChain(any());
             verify(mockAdapter).supports(any());
             verify(mockAdapter, never()).execute(any(), any());
@@ -429,8 +431,8 @@ public class BaseRequestDispatcherTest {
         } catch (AskSdkException ex) {
             verify(globalRequestInterceptor).process(mockInput);
             verify(chainRequestInterceptor).process(mockInput);
-            verify(chainResponseInterceptor, never()).process(mockInput, mockOutput);
-            verify(globalResponseInterceptor, never()).process(mockInput, mockOutput);
+            verify(chainResponseInterceptor, never()).processResponse(mockInput, mockOutput);
+            verify(globalResponseInterceptor, never()).processResponse(mockInput, mockOutput);
             verify(mockMapper).getRequestHandlerChain(any());
             verify(mockAdapter).supports(any());
             verify(mockAdapter).execute(any(), any());
@@ -452,7 +454,7 @@ public class BaseRequestDispatcherTest {
         when(mockHandlerChain.getResponseInterceptors()).thenReturn(Collections.singletonList(chainResponseInterceptor));
 
         Exception e = new IllegalStateException();
-        doThrow(e).when(chainResponseInterceptor).process(any(), any());
+        doThrow(e).when(chainResponseInterceptor).processResponse(any(), any());
         when(mockExceptionMapper.getHandler(any(), any())).thenReturn(Optional.empty());
         try {
             dispatcher.dispatch(mockInput);
@@ -460,8 +462,8 @@ public class BaseRequestDispatcherTest {
         } catch (AskSdkException ex) {
             verify(globalRequestInterceptor).process(mockInput);
             verify(chainRequestInterceptor).process(mockInput);
-            verify(chainResponseInterceptor).process(mockInput, mockOutput);
-            verify(globalResponseInterceptor, never()).process(mockInput, mockOutput);
+            verify(chainResponseInterceptor).processResponse(mockInput, mockOutput);
+            verify(globalResponseInterceptor, never()).processResponse(mockInput, mockOutput);
             verify(mockMapper).getRequestHandlerChain(any());
             verify(mockAdapter).supports(any());
             verify(mockAdapter).execute(any(), any());
@@ -483,7 +485,8 @@ public class BaseRequestDispatcherTest {
         when(mockHandlerChain.getResponseInterceptors()).thenReturn(Collections.singletonList(chainResponseInterceptor));
 
         Exception e = new IllegalStateException();
-        doThrow(e).when(globalResponseInterceptor).process(any(), any());
+        when(chainResponseInterceptor.processResponse(mockInput, mockOutput)).thenReturn(mockOutput);
+        doThrow(e).when(globalResponseInterceptor).processResponse(any(), any());
         when(mockExceptionMapper.getHandler(any(), any())).thenReturn(Optional.empty());
         try {
             dispatcher.dispatch(mockInput);
@@ -491,8 +494,8 @@ public class BaseRequestDispatcherTest {
         } catch (AskSdkException ex) {
             verify(globalRequestInterceptor).process(mockInput);
             verify(chainRequestInterceptor).process(mockInput);
-            verify(chainResponseInterceptor).process(mockInput, mockOutput);
-            verify(globalResponseInterceptor).process(mockInput, mockOutput);
+            verify(chainResponseInterceptor).processResponse(mockInput, mockOutput);
+            verify(globalResponseInterceptor).processResponse(mockInput, mockOutput);
             verify(mockMapper).getRequestHandlerChain(any());
             verify(mockAdapter).supports(any());
             verify(mockAdapter).execute(any(), any());

--- a/ask-sdk-runtime/tst/com/amazon/ask/request/interceptor/GenericResponseInterceptorTest.java
+++ b/ask-sdk-runtime/tst/com/amazon/ask/request/interceptor/GenericResponseInterceptorTest.java
@@ -1,0 +1,36 @@
+/*
+    Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+    Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file
+    except in compliance with the License. A copy of the License is located at
+
+        http://aws.amazon.com/apache2.0/
+
+    or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for
+    the specific language governing permissions and limitations under the License.
+ */
+
+package com.amazon.ask.request.interceptor;
+
+import com.amazon.ask.sdk.TestHandlerInput;
+import com.amazon.ask.sdk.TestHandlerOutput;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class GenericResponseInterceptorTest {
+
+    @Test
+    public void original_response_returned_by_default() {
+        GenericResponseInterceptor<TestHandlerInput, TestHandlerOutput> testInterceptor
+                = new GenericResponseInterceptor<TestHandlerInput, TestHandlerOutput>() {
+            @Override
+            public void process(TestHandlerInput testHandlerInput, TestHandlerOutput response) { }
+        };
+        TestHandlerInput testHandlerInput = new TestHandlerInput();
+        TestHandlerOutput testHandlerOutput = new TestHandlerOutput();
+        assertEquals(testInterceptor.processResponse(testHandlerInput, testHandlerOutput), testHandlerOutput);
+    }
+
+}


### PR DESCRIPTION
## Description
Adds a new response interceptor method that allows the interceptor to return an updated response. This method has a default implementation in the interface to retain backwards compatibility. The existing method has also been made default, and I will likely mark it deprecated at some point in the future. The new method is now called by the dispatcher, which by default will proxy it to the existing method unless overridden in the user's interceptor implementation.

The other approach would be to introduce an entirely new response interceptor interface which would in some ways be a cleaner solution, but was not chosen due to discoverability concerns and loss of parity with other language SDKs.

## Motivation and Context
This change is in response to #206 where a customer wants the ability to update the response as part of their response interceptor logic.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [x] I have added tests to cover my changes
- [ ] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/alexa/alexa-skills-kit-sdk-for-java/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement

