### PR TITLE
Add abstraction layer over servlet interface when calling Verifiers

### DIFF
--- a/ask-sdk-servlet-support/src/com/amazon/ask/servlet/SkillServlet.java
+++ b/ask-sdk-servlet-support/src/com/amazon/ask/servlet/SkillServlet.java
@@ -33,6 +33,8 @@ import com.amazon.ask.model.RequestEnvelope;
 import com.amazon.ask.model.ResponseEnvelope;
 import com.amazon.ask.model.services.Serializer;
 import com.amazon.ask.servlet.util.ServletUtils;
+import com.amazon.ask.servlet.verifiers.ServerRequest;
+import com.amazon.ask.servlet.verifiers.ServletRequest;
 import com.amazon.ask.servlet.verifiers.SkillRequestSignatureVerifier;
 import com.amazon.ask.servlet.verifiers.SkillRequestTimestampVerifier;
 import com.amazon.ask.servlet.verifiers.SkillServletVerifier;
@@ -97,9 +99,11 @@ public class SkillServlet extends HttpServlet {
             final RequestEnvelope deserializedRequestEnvelope = serializer.deserialize(IOUtils.toString(
                     serializedRequestEnvelope, ServletConstants.CHARACTER_ENCODING), RequestEnvelope.class);
 
+            final ServerRequest serverRequest = new ServletRequest(request, serializedRequestEnvelope, deserializedRequestEnvelope);
+
             // Verify the authenticity of the request by executing configured verifiers.
             for (SkillServletVerifier verifier : verifiers) {
-                verifier.verify(request, serializedRequestEnvelope, deserializedRequestEnvelope);
+                verifier.verify(serverRequest);
             }
 
             ResponseEnvelope skillResponse = skill.invoke(deserializedRequestEnvelope);

--- a/ask-sdk-servlet-support/src/com/amazon/ask/servlet/SkillServlet.java
+++ b/ask-sdk-servlet-support/src/com/amazon/ask/servlet/SkillServlet.java
@@ -33,7 +33,7 @@ import com.amazon.ask.model.RequestEnvelope;
 import com.amazon.ask.model.ResponseEnvelope;
 import com.amazon.ask.model.services.Serializer;
 import com.amazon.ask.servlet.util.ServletUtils;
-import com.amazon.ask.servlet.verifiers.ServerRequest;
+import com.amazon.ask.servlet.verifiers.AlexaHttpRequest;
 import com.amazon.ask.servlet.verifiers.ServletRequest;
 import com.amazon.ask.servlet.verifiers.SkillRequestSignatureVerifier;
 import com.amazon.ask.servlet.verifiers.SkillRequestTimestampVerifier;
@@ -44,7 +44,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static com.amazon.ask.servlet.ServletConstants.DEFAULT_TOLERANCE_MILLIS;
-import static com.amazon.ask.servlet.ServletConstants.TIMESTAMP_TOLERANCE_SYSTEM_PROPERTY;
 
 /**
  * <p>
@@ -99,11 +98,11 @@ public class SkillServlet extends HttpServlet {
             final RequestEnvelope deserializedRequestEnvelope = serializer.deserialize(IOUtils.toString(
                     serializedRequestEnvelope, ServletConstants.CHARACTER_ENCODING), RequestEnvelope.class);
 
-            final ServerRequest serverRequest = new ServletRequest(request, serializedRequestEnvelope, deserializedRequestEnvelope);
+            final AlexaHttpRequest alexaHttpRequest = new ServletRequest(request, serializedRequestEnvelope, deserializedRequestEnvelope);
 
             // Verify the authenticity of the request by executing configured verifiers.
             for (SkillServletVerifier verifier : verifiers) {
-                verifier.verify(serverRequest);
+                verifier.verify(alexaHttpRequest);
             }
 
             ResponseEnvelope skillResponse = skill.invoke(deserializedRequestEnvelope);

--- a/ask-sdk-servlet-support/src/com/amazon/ask/servlet/verifiers/AlexaHttpRequest.java
+++ b/ask-sdk-servlet-support/src/com/amazon/ask/servlet/verifiers/AlexaHttpRequest.java
@@ -18,7 +18,7 @@ import com.amazon.ask.model.RequestEnvelope;
 /**
  * Provides container for server request that should be validated
  */
-public interface ServerRequest {
+public interface AlexaHttpRequest {
     /**
      * @return the signature, base64 encoded.
      */

--- a/ask-sdk-servlet-support/src/com/amazon/ask/servlet/verifiers/ServerRequest.java
+++ b/ask-sdk-servlet-support/src/com/amazon/ask/servlet/verifiers/ServerRequest.java
@@ -1,0 +1,41 @@
+/*
+    Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+    Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file
+    except in compliance with the License. A copy of the License is located at
+
+        http://aws.amazon.com/apache2.0/
+
+    or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for
+    the specific language governing permissions and limitations under the License.
+ */
+
+package com.amazon.ask.servlet.verifiers;
+
+import com.amazon.ask.model.RequestEnvelope;
+
+/**
+ * Provides container for server request that should be validated
+ */
+public interface ServerRequest {
+    /**
+     * @return the signature, base64 encoded.
+     */
+    String getBaseEncoded64Signature();
+
+    /**
+     * @return URL for the certificate chain needed to verify the request signature.
+     */
+    String getSigningCertificateChainUrl();
+
+    /**
+     * @return the request envelope, in serialized form.
+     */
+    byte[] getSerializedRequestEnvelope();
+
+    /**
+     * @return the request envelope, in deserialized form.
+     */
+    RequestEnvelope getDeserializedRequestEnvelope();
+}

--- a/ask-sdk-servlet-support/src/com/amazon/ask/servlet/verifiers/ServletRequest.java
+++ b/ask-sdk-servlet-support/src/com/amazon/ask/servlet/verifiers/ServletRequest.java
@@ -1,0 +1,70 @@
+/*
+    Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+    Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file
+    except in compliance with the License. A copy of the License is located at
+
+        http://aws.amazon.com/apache2.0/
+
+    or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for
+    the specific language governing permissions and limitations under the License.
+ */
+
+package com.amazon.ask.servlet.verifiers;
+
+import com.amazon.ask.model.RequestEnvelope;
+import com.amazon.ask.servlet.ServletConstants;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * Servlet specific implementation of {@link ServerRequest}.
+ */
+public class ServletRequest implements ServerRequest {
+
+    private final byte[] serializedRequestEnvelope;
+    private final RequestEnvelope deserializedRequestEnvelope;
+    private final String baseEncoded64Signature;
+    private final String signingCertificateChainUrl;
+
+    public ServletRequest(final HttpServletRequest httpServletRequest, final byte[] serializedRequestEnvelope, final RequestEnvelope deserializedRequestEnvelope) {
+        this.serializedRequestEnvelope = serializedRequestEnvelope;
+        this.deserializedRequestEnvelope = deserializedRequestEnvelope;
+        this.baseEncoded64Signature = httpServletRequest.getHeader(ServletConstants.SIGNATURE_REQUEST_HEADER);
+        this.signingCertificateChainUrl = httpServletRequest.getHeader(ServletConstants.SIGNATURE_CERTIFICATE_CHAIN_URL_REQUEST_HEADER);
+
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getBaseEncoded64Signature() {
+        return baseEncoded64Signature;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getSigningCertificateChainUrl() {
+        return signingCertificateChainUrl;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public byte[] getSerializedRequestEnvelope() {
+        return serializedRequestEnvelope;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public RequestEnvelope getDeserializedRequestEnvelope() {
+        return deserializedRequestEnvelope;
+    }
+}

--- a/ask-sdk-servlet-support/src/com/amazon/ask/servlet/verifiers/ServletRequest.java
+++ b/ask-sdk-servlet-support/src/com/amazon/ask/servlet/verifiers/ServletRequest.java
@@ -19,9 +19,9 @@ import com.amazon.ask.servlet.ServletConstants;
 import javax.servlet.http.HttpServletRequest;
 
 /**
- * Servlet specific implementation of {@link ServerRequest}.
+ * Servlet specific implementation of {@link AlexaHttpRequest}.
  */
-public class ServletRequest implements ServerRequest {
+public class ServletRequest implements AlexaHttpRequest {
 
     private final byte[] serializedRequestEnvelope;
     private final RequestEnvelope deserializedRequestEnvelope;
@@ -33,7 +33,6 @@ public class ServletRequest implements ServerRequest {
         this.deserializedRequestEnvelope = deserializedRequestEnvelope;
         this.baseEncoded64Signature = httpServletRequest.getHeader(ServletConstants.SIGNATURE_REQUEST_HEADER);
         this.signingCertificateChainUrl = httpServletRequest.getHeader(ServletConstants.SIGNATURE_CERTIFICATE_CHAIN_URL_REQUEST_HEADER);
-
     }
 
     /**

--- a/ask-sdk-servlet-support/src/com/amazon/ask/servlet/verifiers/SkillRequestSignatureVerifier.java
+++ b/ask-sdk-servlet-support/src/com/amazon/ask/servlet/verifiers/SkillRequestSignatureVerifier.java
@@ -70,9 +70,9 @@ public final class SkillRequestSignatureVerifier implements SkillServletVerifier
      *
      * {@inheritDoc}
      */
-    public void verify(ServerRequest serverRequest) {
-        String baseEncoded64Signature = serverRequest.getBaseEncoded64Signature();
-        String signingCertificateChainUrl = serverRequest.getSigningCertificateChainUrl();
+    public void verify(AlexaHttpRequest alexaHttpRequest) {
+        String baseEncoded64Signature = alexaHttpRequest.getBaseEncoded64Signature();
+        String signingCertificateChainUrl = alexaHttpRequest.getSigningCertificateChainUrl();
         if ((baseEncoded64Signature == null) || (signingCertificateChainUrl == null)) {
             throw new SecurityException(
                     "Missing signature/certificate for the provided skill request");
@@ -97,7 +97,7 @@ public final class SkillRequestSignatureVerifier implements SkillServletVerifier
             // verify that the request was signed by the provided certificate
             Signature signature = Signature.getInstance(ServletConstants.SIGNATURE_ALGORITHM);
             signature.initVerify(signingCertificate.getPublicKey());
-            signature.update(serverRequest.getSerializedRequestEnvelope());
+            signature.update(alexaHttpRequest.getSerializedRequestEnvelope());
             if (!signature.verify(Base64.decodeBase64(baseEncoded64Signature
                     .getBytes(ServletConstants.CHARACTER_ENCODING)))) {
                 throw new SecurityException(

--- a/ask-sdk-servlet-support/src/com/amazon/ask/servlet/verifiers/SkillRequestSignatureVerifier.java
+++ b/ask-sdk-servlet-support/src/com/amazon/ask/servlet/verifiers/SkillRequestSignatureVerifier.java
@@ -13,14 +13,12 @@
 
 package com.amazon.ask.servlet.verifiers;
 
-import com.amazon.ask.model.RequestEnvelope;
 import com.amazon.ask.servlet.ServletConstants;
 import org.apache.commons.codec.binary.Base64;
 
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.TrustManagerFactory;
 import javax.net.ssl.X509TrustManager;
-import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
@@ -72,9 +70,9 @@ public final class SkillRequestSignatureVerifier implements SkillServletVerifier
      *
      * {@inheritDoc}
      */
-    public void verify(HttpServletRequest servletRequest, byte[] serializedRequestEnvelope, RequestEnvelope deserializedRequestEnvelope) {
-        String baseEncoded64Signature = servletRequest.getHeader(ServletConstants.SIGNATURE_REQUEST_HEADER);
-        String signingCertificateChainUrl = servletRequest.getHeader(ServletConstants.SIGNATURE_CERTIFICATE_CHAIN_URL_REQUEST_HEADER);
+    public void verify(ServerRequest serverRequest) {
+        String baseEncoded64Signature = serverRequest.getBaseEncoded64Signature();
+        String signingCertificateChainUrl = serverRequest.getSigningCertificateChainUrl();
         if ((baseEncoded64Signature == null) || (signingCertificateChainUrl == null)) {
             throw new SecurityException(
                     "Missing signature/certificate for the provided skill request");
@@ -99,7 +97,7 @@ public final class SkillRequestSignatureVerifier implements SkillServletVerifier
             // verify that the request was signed by the provided certificate
             Signature signature = Signature.getInstance(ServletConstants.SIGNATURE_ALGORITHM);
             signature.initVerify(signingCertificate.getPublicKey());
-            signature.update(serializedRequestEnvelope);
+            signature.update(serverRequest.getSerializedRequestEnvelope());
             if (!signature.verify(Base64.decodeBase64(baseEncoded64Signature
                     .getBytes(ServletConstants.CHARACTER_ENCODING)))) {
                 throw new SecurityException(

--- a/ask-sdk-servlet-support/src/com/amazon/ask/servlet/verifiers/SkillRequestTimestampVerifier.java
+++ b/ask-sdk-servlet-support/src/com/amazon/ask/servlet/verifiers/SkillRequestTimestampVerifier.java
@@ -14,11 +14,8 @@
 package com.amazon.ask.servlet.verifiers;
 
 import com.amazon.ask.model.Request;
-import com.amazon.ask.model.RequestEnvelope;
 import com.amazon.ask.servlet.ServletConstants;
 import com.amazon.ask.util.ValidationUtils;
-
-import javax.servlet.http.HttpServletRequest;
 
 import java.util.concurrent.TimeUnit;
 
@@ -78,11 +75,11 @@ public class SkillRequestTimestampVerifier implements SkillServletVerifier {
      *
      * {@inheritDoc}
      */
-    public void verify(HttpServletRequest servletRequest, byte[] serializedRequestEnvelope, RequestEnvelope deserializedRequestEnvelope) {
-        if (deserializedRequestEnvelope == null) {
+    public void verify(ServerRequest serverRequest) {
+        if (serverRequest.getDeserializedRequestEnvelope() == null) {
             throw new SecurityException("Incoming request did not contain a request envelope");
         }
-        Request request = deserializedRequestEnvelope.getRequest();
+        Request request = serverRequest.getDeserializedRequestEnvelope().getRequest();
         if (request == null || request.getTimestamp() == null) {
             throw new SecurityException("Incoming request was null or did not contain a timestamp to evaluate");
         }

--- a/ask-sdk-servlet-support/src/com/amazon/ask/servlet/verifiers/SkillRequestTimestampVerifier.java
+++ b/ask-sdk-servlet-support/src/com/amazon/ask/servlet/verifiers/SkillRequestTimestampVerifier.java
@@ -75,11 +75,11 @@ public class SkillRequestTimestampVerifier implements SkillServletVerifier {
      *
      * {@inheritDoc}
      */
-    public void verify(ServerRequest serverRequest) {
-        if (serverRequest.getDeserializedRequestEnvelope() == null) {
+    public void verify(AlexaHttpRequest alexaHttpRequest) {
+        if (alexaHttpRequest.getDeserializedRequestEnvelope() == null) {
             throw new SecurityException("Incoming request did not contain a request envelope");
         }
-        Request request = serverRequest.getDeserializedRequestEnvelope().getRequest();
+        Request request = alexaHttpRequest.getDeserializedRequestEnvelope().getRequest();
         if (request == null || request.getTimestamp() == null) {
             throw new SecurityException("Incoming request was null or did not contain a timestamp to evaluate");
         }

--- a/ask-sdk-servlet-support/src/com/amazon/ask/servlet/verifiers/SkillServletVerifier.java
+++ b/ask-sdk-servlet-support/src/com/amazon/ask/servlet/verifiers/SkillServletVerifier.java
@@ -13,10 +13,6 @@
 
 package com.amazon.ask.servlet.verifiers;
 
-import com.amazon.ask.model.RequestEnvelope;
-
-import javax.servlet.http.HttpServletRequest;
-
 /**
  * Verifiers are run against incoming requests to verify authenticity and integrity of the request before processing
  * it.
@@ -24,13 +20,11 @@ import javax.servlet.http.HttpServletRequest;
 public interface SkillServletVerifier {
 
     /**
-     * Verifies an incoming request.
+     * Verifies an incoming serverRequest.
      *
-     * @param servletRequest servlet request
-     * @param serializedRequestEnvelope the request envelope, in serialized form
-     * @param deserializedRequestEnvelope the request envelope, in deserialized form
+     * @param serverRequest serverRequest
      * @throws SecurityException if verification fails.
      */
-    void verify(HttpServletRequest servletRequest, byte[] serializedRequestEnvelope, RequestEnvelope deserializedRequestEnvelope) throws SecurityException;
+    void verify(ServerRequest serverRequest) throws SecurityException;
 
 }

--- a/ask-sdk-servlet-support/src/com/amazon/ask/servlet/verifiers/SkillServletVerifier.java
+++ b/ask-sdk-servlet-support/src/com/amazon/ask/servlet/verifiers/SkillServletVerifier.java
@@ -20,7 +20,7 @@ package com.amazon.ask.servlet.verifiers;
 public interface SkillServletVerifier {
 
     /**
-     * Verifies an incoming serverRequest.
+     * Verifies an incoming request.
      *
      * @param serverRequest serverRequest
      * @throws SecurityException if verification fails.

--- a/ask-sdk-servlet-support/src/com/amazon/ask/servlet/verifiers/SkillServletVerifier.java
+++ b/ask-sdk-servlet-support/src/com/amazon/ask/servlet/verifiers/SkillServletVerifier.java
@@ -22,9 +22,9 @@ public interface SkillServletVerifier {
     /**
      * Verifies an incoming request.
      *
-     * @param serverRequest serverRequest
+     * @param alexaHttpRequest request performed by Alexa
      * @throws SecurityException if verification fails.
      */
-    void verify(ServerRequest serverRequest) throws SecurityException;
+    void verify(AlexaHttpRequest alexaHttpRequest) throws SecurityException;
 
 }

--- a/ask-sdk-servlet-support/tst/com/amazon/ask/servlet/SkillServletTest.java
+++ b/ask-sdk-servlet-support/tst/com/amazon/ask/servlet/SkillServletTest.java
@@ -71,20 +71,20 @@ public class SkillServletTest extends SkillServletTestBase {
         ServletInvocationParameters invocation = build(FORMAT_VERSION, request, buildSession());
         servlet.doPost(invocation.request, invocation.response);
         verify(invocation.response).setStatus(HttpServletResponse.SC_OK);
-        verify(mockVerifier).verify(any(), any(), any());
+        verify(mockVerifier).verify(any());
     }
 
     @Test
     public void doPost_failedVerification_responseBadRequest() throws Exception {
         SkillServletVerifier mockVerifier = mock(SkillServletVerifier.class);
-        doThrow(new SecurityException("foo")).when(mockVerifier).verify(any(), any(), any());
+        doThrow(new SecurityException("foo")).when(mockVerifier).verify(any());
         SkillServlet servlet = new SkillServlet(skill, Collections.singletonList(mockVerifier));
         OffsetDateTime timestamp = OffsetDateTime.ofInstant(new Date().toInstant(), ZoneId.systemDefault());
         LaunchRequest request = LaunchRequest.builder().withRequestId("rId").withLocale(LOCALE).withTimestamp(timestamp).build();
         ServletInvocationParameters invocation = build(FORMAT_VERSION, request, buildSession());
         servlet.doPost(invocation.request, invocation.response);
         verify(invocation.response).sendError(eq(HttpServletResponse.SC_BAD_REQUEST), anyString());
-        verify(mockVerifier).verify(any(), any(), any());
+        verify(mockVerifier).verify(any());
     }
 
     @Test

--- a/ask-sdk-servlet-support/tst/com/amazon/ask/servlet/verifiers/SkillRequestSignatureVerifierTest.java
+++ b/ask-sdk-servlet-support/tst/com/amazon/ask/servlet/verifiers/SkillRequestSignatureVerifierTest.java
@@ -37,7 +37,6 @@ import javax.servlet.http.HttpServletRequest;
 
 import com.amazon.ask.model.RequestEnvelope;
 import com.amazon.ask.servlet.ServletConstants;
-import com.amazon.ask.servlet.verifiers.SkillRequestSignatureVerifier;
 import org.apache.commons.codec.binary.Base64;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.x509.X509V3CertificateGenerator;
@@ -205,7 +204,8 @@ public class SkillRequestSignatureVerifierTest {
         byte[] signature = signContent(testContent, validPrivateKey);
         when(mockServletRequest.getHeader(ServletConstants.SIGNATURE_REQUEST_HEADER)).thenReturn(new Base64().encodeAsString(signature));
         when(mockServletRequest.getHeader(ServletConstants.SIGNATURE_CERTIFICATE_CHAIN_URL_REQUEST_HEADER)).thenReturn(PREPOPULATED_CERT_URL);
-        verifier.verify(mockServletRequest, testContent.getBytes(), deserializedRequestEnvelope);
+
+        verifier.verify(new ServletRequest(mockServletRequest, testContent.getBytes(), deserializedRequestEnvelope));
     }
 
     @Test
@@ -220,7 +220,7 @@ public class SkillRequestSignatureVerifierTest {
         when(mockServletRequest.getHeader(ServletConstants.SIGNATURE_REQUEST_HEADER)).thenReturn(new Base64().encodeAsString(signature));
         when(mockServletRequest.getHeader(ServletConstants.SIGNATURE_CERTIFICATE_CHAIN_URL_REQUEST_HEADER)).thenReturn(PREPOPULATED_CERT_URL);
 
-        verifier.verify(mockServletRequest, testContent.getBytes(), deserializedRequestEnvelope);
+        verifier.verify(new ServletRequest(mockServletRequest, testContent.getBytes(), deserializedRequestEnvelope));
     }
 
     private static KeyPair generateKeyPair() throws NoSuchAlgorithmException {

--- a/ask-sdk-servlet-support/tst/com/amazon/ask/servlet/verifiers/SkillRequestTimestampVerifierTest.java
+++ b/ask-sdk-servlet-support/tst/com/amazon/ask/servlet/verifiers/SkillRequestTimestampVerifierTest.java
@@ -69,47 +69,47 @@ public class SkillRequestTimestampVerifierTest {
 
     @Test
     public void verify_currentDate_no_exception() {
-        verifier.verify(mockServletRequest, serializedRequestEnvelope, getRequestEnvelope(new Date()));
+        verifier.verify(new ServletRequest(mockServletRequest, serializedRequestEnvelope, getRequestEnvelope(new Date())));
     }
 
     @Test
     public void verify_recentOldDate_no_exception() {
-        verifier.verify(mockServletRequest, serializedRequestEnvelope, getRequestEnvelope(new Date(System.currentTimeMillis() - TOLERANCE_IN_MILLIS / 2)));
+        verifier.verify(new ServletRequest(mockServletRequest, serializedRequestEnvelope, getRequestEnvelope(new Date(System.currentTimeMillis() - TOLERANCE_IN_MILLIS / 2))));
     }
 
     @Test
     public void verify_upcomingNewDate_no_exception() {
-        verifier.verify(mockServletRequest, serializedRequestEnvelope, getRequestEnvelope(new Date(System.currentTimeMillis() + TOLERANCE_IN_MILLIS / 2)));
+        verifier.verify(new ServletRequest(mockServletRequest, serializedRequestEnvelope, getRequestEnvelope(new Date(System.currentTimeMillis() + TOLERANCE_IN_MILLIS / 2))));
     }
 
     @Test(expected = SecurityException.class)
     public void verify_tooOldDate_throws_exception() {
-        verifier.verify(mockServletRequest, serializedRequestEnvelope, getRequestEnvelope(new Date(System.currentTimeMillis() - TOLERANCE_IN_MILLIS * 2)));
+        verifier.verify(new ServletRequest(mockServletRequest, serializedRequestEnvelope, getRequestEnvelope(new Date(System.currentTimeMillis() - TOLERANCE_IN_MILLIS * 2))));
     }
 
     @Test(expected = SecurityException.class)
     public void verify_tooNewDate_throws_exception() {
-        verifier.verify(mockServletRequest, serializedRequestEnvelope, getRequestEnvelope(new Date(System.currentTimeMillis() + TOLERANCE_IN_MILLIS * 2)));
+        verifier.verify(new ServletRequest(mockServletRequest, serializedRequestEnvelope, getRequestEnvelope(new Date(System.currentTimeMillis() + TOLERANCE_IN_MILLIS * 2))));
     }
 
     @Test(expected = SecurityException.class)
     public void verify_nullDate_throws_exception() {
-        verifier.verify(mockServletRequest, serializedRequestEnvelope, getRequestEnvelope(null));
+        verifier.verify(new ServletRequest(mockServletRequest, serializedRequestEnvelope, getRequestEnvelope(null)));
     }
 
     @Test(expected = SecurityException.class)
     public void verify_nullRequestEnvelope_throws_exception() {
-        verifier.verify(mockServletRequest, serializedRequestEnvelope, null);
+        verifier.verify(new ServletRequest(mockServletRequest, serializedRequestEnvelope, null));
     }
 
     @Test(expected = SecurityException.class)
     public void verify_nullRequest_throws_exception() {
-        verifier.verify(mockServletRequest, serializedRequestEnvelope, RequestEnvelope.builder().build());
+        verifier.verify(new ServletRequest(mockServletRequest, serializedRequestEnvelope, RequestEnvelope.builder().build()));
     }
 
     @Test(expected = SecurityException.class)
     public void verify_nullTimestamp_throws_exception() {
-        verifier.verify(mockServletRequest, serializedRequestEnvelope, RequestEnvelope.builder().withRequest(IntentRequest.builder().build()).build());
+        verifier.verify(new ServletRequest(mockServletRequest, serializedRequestEnvelope, RequestEnvelope.builder().withRequest(IntentRequest.builder().build()).build()));
     }
 
     @Test (expected = IllegalArgumentException.class)
@@ -119,7 +119,7 @@ public class SkillRequestTimestampVerifierTest {
 
     @Test(expected = SecurityException.class)
     public void verify_withGreaterRequestTimeDelta_throws_exception() {
-        verifier.verify(mockServletRequest, serializedRequestEnvelope, getRequestEnvelope(new Date(System.currentTimeMillis() + TOLERANCE_IN_MILLIS + 200)));
+        verifier.verify(new ServletRequest(mockServletRequest, serializedRequestEnvelope, getRequestEnvelope(new Date(System.currentTimeMillis() + TOLERANCE_IN_MILLIS + 200))));
     }
 
     private RequestEnvelope getRequestEnvelope(Date timestamp) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Providing interface over `HttpServletRequest` in order to use verifiers non-servlet contexts - like reactive solutions, gateways etc.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->
Currently it's impossible to use validators without servlet API. After the change it's possible to create other implementations of `Request` like `ReactiveRequest` etc.  

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
All existing test cases cover refactored code.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/alexa/alexa-skills-kit-sdk-for-java/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement

