### PR TITLE
Add request interceptor method for returning modified request

### DIFF
--- a/ask-sdk-core/tst/com/amazon/ask/dispatcher/DefaultRequestDispatcherTest.java
+++ b/ask-sdk-core/tst/com/amazon/ask/dispatcher/DefaultRequestDispatcherTest.java
@@ -222,12 +222,14 @@ public class DefaultRequestDispatcherTest {
     public void handler_chain_level_request_interceptor_called_after_global_interceptor() {
         RequestInterceptor globalInterceptor = mock(RequestInterceptor.class);
         RequestInterceptor chainInterceptor = mock(RequestInterceptor.class);
+        when(globalInterceptor.processRequest(handlerInput)).thenReturn(handlerInput);
+        when(chainInterceptor.processRequest(handlerInput)).thenReturn(handlerInput);
         requestInterceptors.add(globalInterceptor);
         doReturn(Collections.singletonList(chainInterceptor)).when(mockHandlerChain).getRequestInterceptors();
         dispatcher.dispatch(handlerInput);
         InOrder inOrder = inOrder(globalInterceptor, chainInterceptor, mockAdapter);
-        inOrder.verify(globalInterceptor).process(handlerInput);
-        inOrder.verify(chainInterceptor).process(handlerInput);
+        inOrder.verify(globalInterceptor).processRequest(handlerInput);
+        inOrder.verify(chainInterceptor).processRequest(handlerInput);
         inOrder.verify(mockAdapter).execute(any(), any());
     }
 
@@ -252,11 +254,13 @@ public class DefaultRequestDispatcherTest {
         requestInterceptors.add(globalRequestInterceptor);
         doReturn(Collections.singletonList(chainRequestInterceptor)).when(mockHandlerChain).getRequestInterceptors();
 
-
         ResponseInterceptor globalResponseInterceptor = mock(ResponseInterceptor.class);
         ResponseInterceptor chainResponseInterceptor = mock(ResponseInterceptor.class);
         responseInterceptors.add(globalResponseInterceptor);
         doReturn(Collections.singletonList(chainResponseInterceptor)).when(mockHandlerChain).getResponseInterceptors();
+
+        when(globalRequestInterceptor.processRequest(handlerInput)).thenReturn(handlerInput);
+        when(chainRequestInterceptor.processRequest(handlerInput)).thenReturn(handlerInput);
 
         when(mockMapper.getRequestHandlerChain(any())).thenReturn(Optional.empty());
         when(mockExceptionMapper.getHandler(any(), any())).thenReturn(Optional.empty());
@@ -264,10 +268,10 @@ public class DefaultRequestDispatcherTest {
             dispatcher.dispatch(handlerInput);
             fail("Unhandled skill exception should have been thrown");
         } catch (UnhandledSkillException ex) {
-            verify(globalRequestInterceptor).process(handlerInput);
-            verify(chainRequestInterceptor, never()).process(handlerInput);
-            verify(chainResponseInterceptor, never()).process(handlerInput, Optional.of(mockResponse));
-            verify(globalResponseInterceptor, never()).process(handlerInput, Optional.of(mockResponse));
+            verify(globalRequestInterceptor).processRequest(handlerInput);
+            verify(chainRequestInterceptor, never()).processRequest(handlerInput);
+            verify(chainResponseInterceptor, never()).processResponse(handlerInput, Optional.of(mockResponse));
+            verify(globalResponseInterceptor, never()).processResponse(handlerInput, Optional.of(mockResponse));
             verify(mockMapper).getRequestHandlerChain(any());
             verify(mockAdapter, never()).supports(any());
             verify(mockAdapter, never()).execute(any(), any());
@@ -286,16 +290,19 @@ public class DefaultRequestDispatcherTest {
         responseInterceptors.add(globalResponseInterceptor);
         doReturn(Collections.singletonList(chainResponseInterceptor)).when(mockHandlerChain).getResponseInterceptors();
 
+        when(globalRequestInterceptor.processRequest(handlerInput)).thenReturn(handlerInput);
+        when(chainRequestInterceptor.processRequest(handlerInput)).thenReturn(handlerInput);
+
         when(mockAdapter.supports(any())).thenReturn(false);
         when(mockExceptionMapper.getHandler(any(), any())).thenReturn(Optional.empty());
         try {
             dispatcher.dispatch(handlerInput);
             fail("Unhandled skill exception should have been thrown");
         } catch (UnhandledSkillException ex) {
-            verify(globalRequestInterceptor).process(handlerInput);
-            verify(chainRequestInterceptor, never()).process(handlerInput);
-            verify(chainResponseInterceptor, never()).process(handlerInput, Optional.of(mockResponse));
-            verify(globalResponseInterceptor, never()).process(handlerInput, Optional.of(mockResponse));
+            verify(globalRequestInterceptor).processRequest(handlerInput);
+            verify(chainRequestInterceptor, never()).processRequest(handlerInput);
+            verify(chainResponseInterceptor, never()).processResponse(handlerInput, Optional.of(mockResponse));
+            verify(globalResponseInterceptor, never()).processResponse(handlerInput, Optional.of(mockResponse));
             verify(mockMapper).getRequestHandlerChain(any());
             verify(mockAdapter).supports(any());
             verify(mockAdapter, never()).execute(any(), any());
@@ -315,16 +322,16 @@ public class DefaultRequestDispatcherTest {
         doReturn(Collections.singletonList(chainResponseInterceptor)).when(mockHandlerChain).getResponseInterceptors();
 
         Exception e = new IllegalStateException();
-        doThrow(e).when(globalRequestInterceptor).process(any());
+        doThrow(e).when(globalRequestInterceptor).processRequest(any());
         when(mockExceptionMapper.getHandler(any(), any())).thenReturn(Optional.empty());
         try {
             dispatcher.dispatch(handlerInput);
             fail("Unhandled skill exception should have been thrown");
         } catch (UnhandledSkillException ex) {
-            verify(globalRequestInterceptor).process(handlerInput);
-            verify(chainRequestInterceptor, never()).process(handlerInput);
-            verify(chainResponseInterceptor, never()).process(handlerInput, Optional.of(mockResponse));
-            verify(globalResponseInterceptor, never()).process(handlerInput, Optional.of(mockResponse));
+            verify(globalRequestInterceptor).processRequest(handlerInput);
+            verify(chainRequestInterceptor, never()).processRequest(handlerInput);
+            verify(chainResponseInterceptor, never()).processResponse(handlerInput, Optional.of(mockResponse));
+            verify(globalResponseInterceptor, never()).processResponse(handlerInput, Optional.of(mockResponse));
             verify(mockMapper, never()).getRequestHandlerChain(any());
             verify(mockAdapter, never()).supports(any());
             verify(mockAdapter, never()).execute(any(), any());
@@ -343,17 +350,20 @@ public class DefaultRequestDispatcherTest {
         responseInterceptors.add(globalResponseInterceptor);
         doReturn(Collections.singletonList(chainResponseInterceptor)).when(mockHandlerChain).getResponseInterceptors();
 
+        when(globalRequestInterceptor.processRequest(handlerInput)).thenReturn(handlerInput);
+        when(chainRequestInterceptor.processRequest(handlerInput)).thenReturn(handlerInput);
+
         Exception e = new IllegalStateException();
-        doThrow(e).when(chainRequestInterceptor).process(any());
+        doThrow(e).when(chainRequestInterceptor).processRequest(any());
         when(mockExceptionMapper.getHandler(any(), any())).thenReturn(Optional.empty());
         try {
             dispatcher.dispatch(handlerInput);
             fail("Unhandled skill exception should have been thrown");
         } catch (UnhandledSkillException ex) {
-            verify(globalRequestInterceptor).process(handlerInput);
-            verify(chainRequestInterceptor).process(handlerInput);
-            verify(chainResponseInterceptor, never()).process(handlerInput, Optional.of(mockResponse));
-            verify(globalResponseInterceptor, never()).process(handlerInput, Optional.of(mockResponse));
+            verify(globalRequestInterceptor).processRequest(handlerInput);
+            verify(chainRequestInterceptor).processRequest(handlerInput);
+            verify(chainResponseInterceptor, never()).processResponse(handlerInput, Optional.of(mockResponse));
+            verify(globalResponseInterceptor, never()).processResponse(handlerInput, Optional.of(mockResponse));
             verify(mockMapper).getRequestHandlerChain(any());
             verify(mockAdapter).supports(any());
             verify(mockAdapter, never()).execute(any(), any());
@@ -372,6 +382,9 @@ public class DefaultRequestDispatcherTest {
         responseInterceptors.add(globalResponseInterceptor);
         doReturn(Collections.singletonList(chainResponseInterceptor)).when(mockHandlerChain).getResponseInterceptors();
 
+        when(globalRequestInterceptor.processRequest(handlerInput)).thenReturn(handlerInput);
+        when(chainRequestInterceptor.processRequest(handlerInput)).thenReturn(handlerInput);
+
         Exception e = new IllegalStateException();
         when(mockAdapter.execute(any(HandlerInput.class), any(RequestHandler.class))).thenThrow(e);
         when(mockExceptionMapper.getHandler(any(), any())).thenReturn(Optional.empty());
@@ -379,10 +392,10 @@ public class DefaultRequestDispatcherTest {
             dispatcher.dispatch(handlerInput);
             fail("Unhandled skill exception should have been thrown");
         } catch (UnhandledSkillException ex) {
-            verify(globalRequestInterceptor).process(handlerInput);
-            verify(chainRequestInterceptor).process(handlerInput);
-            verify(chainResponseInterceptor, never()).process(handlerInput, Optional.of(mockResponse));
-            verify(globalResponseInterceptor, never()).process(handlerInput, Optional.of(mockResponse));
+            verify(globalRequestInterceptor).processRequest(handlerInput);
+            verify(chainRequestInterceptor).processRequest(handlerInput);
+            verify(chainResponseInterceptor, never()).processResponse(handlerInput, Optional.of(mockResponse));
+            verify(globalResponseInterceptor, never()).processResponse(handlerInput, Optional.of(mockResponse));
             verify(mockMapper).getRequestHandlerChain(any());
             verify(mockAdapter).supports(any());
             verify(mockAdapter).execute(any(), any());
@@ -401,6 +414,9 @@ public class DefaultRequestDispatcherTest {
         responseInterceptors.add(globalResponseInterceptor);
         doReturn(Collections.singletonList(chainResponseInterceptor)).when(mockHandlerChain).getResponseInterceptors();
 
+        when(globalRequestInterceptor.processRequest(handlerInput)).thenReturn(handlerInput);
+        when(chainRequestInterceptor.processRequest(handlerInput)).thenReturn(handlerInput);
+
         Exception e = new IllegalStateException();
         doThrow(e).when(chainResponseInterceptor).processResponse(any(), any());
         when(mockExceptionMapper.getHandler(any(), any())).thenReturn(Optional.empty());
@@ -408,8 +424,8 @@ public class DefaultRequestDispatcherTest {
             dispatcher.dispatch(handlerInput);
             fail("Unhandled skill exception should have been thrown");
         } catch (UnhandledSkillException ex) {
-            verify(globalRequestInterceptor).process(handlerInput);
-            verify(chainRequestInterceptor).process(handlerInput);
+            verify(globalRequestInterceptor).processRequest(handlerInput);
+            verify(chainRequestInterceptor).processRequest(handlerInput);
             verify(chainResponseInterceptor).processResponse(handlerInput, Optional.of(mockResponse));
             verify(globalResponseInterceptor, never()).processResponse(handlerInput, Optional.of(mockResponse));
             verify(mockMapper).getRequestHandlerChain(any());
@@ -431,6 +447,9 @@ public class DefaultRequestDispatcherTest {
         doReturn(Collections.singletonList(chainResponseInterceptor)).when(mockHandlerChain).getResponseInterceptors();
         when(chainResponseInterceptor.processResponse(handlerInput, Optional.of(mockResponse))).thenReturn(Optional.of(mockResponse));
 
+        when(globalRequestInterceptor.processRequest(handlerInput)).thenReturn(handlerInput);
+        when(chainRequestInterceptor.processRequest(handlerInput)).thenReturn(handlerInput);
+
         Exception e = new IllegalStateException();
         doThrow(e).when(globalResponseInterceptor).processResponse(any(), any());
         when(mockExceptionMapper.getHandler(any(), any())).thenReturn(Optional.empty());
@@ -438,8 +457,8 @@ public class DefaultRequestDispatcherTest {
             dispatcher.dispatch(handlerInput);
             fail("Unhandled skill exception should have been thrown");
         } catch (UnhandledSkillException ex) {
-            verify(globalRequestInterceptor).process(handlerInput);
-            verify(chainRequestInterceptor).process(handlerInput);
+            verify(globalRequestInterceptor).processRequest(handlerInput);
+            verify(chainRequestInterceptor).processRequest(handlerInput);
             verify(chainResponseInterceptor).processResponse(handlerInput, Optional.of(mockResponse));
             verify(globalResponseInterceptor).processResponse(handlerInput, Optional.of(mockResponse));
             verify(mockMapper).getRequestHandlerChain(any());

--- a/ask-sdk-runtime/src/com/amazon/ask/request/dispatcher/impl/BaseRequestDispatcher.java
+++ b/ask-sdk-runtime/src/com/amazon/ask/request/dispatcher/impl/BaseRequestDispatcher.java
@@ -84,7 +84,7 @@ public class BaseRequestDispatcher<Input, Output> implements GenericRequestDispa
     private Output doDispatch(Input input) throws Exception {
         // execute any global request interceptors
         for (GenericRequestInterceptor<Input> requestInterceptor : requestInterceptors) {
-            requestInterceptor.process(input);
+            input = requestInterceptor.processRequest(input);
         }
 
         Optional<GenericRequestHandlerChain<Input, Output>> handlerChain = Optional.empty();
@@ -125,7 +125,7 @@ public class BaseRequestDispatcher<Input, Output> implements GenericRequestDispa
         try {
             // execute any request interceptors attached to the handler chain
             for (GenericRequestInterceptor<Input> requestInterceptor : handlerChain.get().getRequestInterceptors()) {
-                requestInterceptor.process(input);
+                input = requestInterceptor.processRequest(input);
             }
 
             // invoke request handler using the adapter
@@ -136,8 +136,9 @@ public class BaseRequestDispatcher<Input, Output> implements GenericRequestDispa
                 response = responseInterceptor.processResponse(input, response);
             }
         } catch (Exception e) {
+            final Input originalInput = input;
             return handlerChain.get().getExceptionHandlers().stream()
-                    .filter(exceptionHandler -> exceptionHandler.canHandle(input, e))
+                    .filter(exceptionHandler -> exceptionHandler.canHandle(originalInput, e))
                     .findFirst()
                     .orElseThrow(() -> e).handle(input, e);
         }

--- a/ask-sdk-runtime/src/com/amazon/ask/request/interceptor/GenericRequestInterceptor.java
+++ b/ask-sdk-runtime/src/com/amazon/ask/request/interceptor/GenericRequestInterceptor.java
@@ -26,6 +26,17 @@ public interface GenericRequestInterceptor<Input> {
      *
      * @param input handler input
      */
-    void process(Input input);
+    default void process(Input input) {}
+
+    /**
+     * Intercept the incoming request before the request handler is executed and return an updated request.
+     *
+     * @param input handler input
+     * @return updated request
+     */
+    default Input processRequest(Input input) {
+        process(input);
+        return input;
+    }
 
 }

--- a/ask-sdk-runtime/tst/com/amazon/ask/request/dispatcher/BaseRequestDispatcherTest.java
+++ b/ask-sdk-runtime/tst/com/amazon/ask/request/dispatcher/BaseRequestDispatcherTest.java
@@ -270,10 +270,12 @@ public class BaseRequestDispatcherTest {
         GenericRequestInterceptor<TestHandlerInput> chainInterceptor = mock(GenericRequestInterceptor.class);
         requestInterceptors.add(globalInterceptor);
         when(mockHandlerChain.getRequestInterceptors()).thenReturn(Collections.singletonList(chainInterceptor));
+        when(globalInterceptor.processRequest(mockInput)).thenReturn(mockInput);
+        when(chainInterceptor.processRequest(mockInput)).thenReturn(mockInput);
         dispatcher.dispatch(mockInput);
         InOrder inOrder = inOrder(globalInterceptor, chainInterceptor, mockAdapter);
-        inOrder.verify(globalInterceptor).process(mockInput);
-        inOrder.verify(chainInterceptor).process(mockInput);
+        inOrder.verify(globalInterceptor).processRequest(mockInput);
+        inOrder.verify(chainInterceptor).processRequest(mockInput);
         inOrder.verify(mockAdapter).execute(any(), any());
     }
 
@@ -310,8 +312,8 @@ public class BaseRequestDispatcherTest {
             dispatcher.dispatch(mockInput);
             fail("Unhandled skill exception should have been thrown");
         } catch (AskSdkException ex) {
-            verify(globalRequestInterceptor).process(mockInput);
-            verify(chainRequestInterceptor, never()).process(mockInput);
+            verify(globalRequestInterceptor).processRequest(mockInput);
+            verify(chainRequestInterceptor, never()).processRequest(mockInput);
             verify(chainResponseInterceptor, never()).processResponse(mockInput, mockOutput);
             verify(globalResponseInterceptor, never()).processResponse(mockInput, mockOutput);
             verify(mockMapper).getRequestHandlerChain(any());
@@ -338,8 +340,8 @@ public class BaseRequestDispatcherTest {
             dispatcher.dispatch(mockInput);
             fail("Unhandled skill exception should have been thrown");
         } catch (AskSdkException ex) {
-            verify(globalRequestInterceptor).process(mockInput);
-            verify(chainRequestInterceptor, never()).process(mockInput);
+            verify(globalRequestInterceptor).processRequest(mockInput);
+            verify(chainRequestInterceptor, never()).processRequest(mockInput);
             verify(chainResponseInterceptor, never()).processResponse(mockInput, mockOutput);
             verify(globalResponseInterceptor, never()).processResponse(mockInput, mockOutput);
             verify(mockMapper).getRequestHandlerChain(any());
@@ -361,14 +363,14 @@ public class BaseRequestDispatcherTest {
         when(mockHandlerChain.getResponseInterceptors()).thenReturn(Collections.singletonList(chainResponseInterceptor));
 
         Exception e = new IllegalStateException();
-        doThrow(e).when(globalRequestInterceptor).process(any());
+        doThrow(e).when(globalRequestInterceptor).processRequest(any());
         when(mockExceptionMapper.getHandler(any(), any())).thenReturn(Optional.empty());
         try {
             dispatcher.dispatch(mockInput);
             fail("Unhandled skill exception should have been thrown");
         } catch (AskSdkException ex) {
-            verify(globalRequestInterceptor).process(mockInput);
-            verify(chainRequestInterceptor, never()).process(mockInput);
+            verify(globalRequestInterceptor).processRequest(mockInput);
+            verify(chainRequestInterceptor, never()).processRequest(mockInput);
             verify(chainResponseInterceptor, never()).processResponse(mockInput, mockOutput);
             verify(globalResponseInterceptor, never()).processResponse(mockInput, mockOutput);
             verify(mockMapper, never()).getRequestHandlerChain(any());
@@ -391,15 +393,18 @@ public class BaseRequestDispatcherTest {
         responseInterceptors.add(globalResponseInterceptor);
         when(mockHandlerChain.getResponseInterceptors()).thenReturn(Collections.singletonList(chainResponseInterceptor));
 
+        when(globalRequestInterceptor.processRequest(mockInput)).thenReturn(mockInput);
+        when(chainRequestInterceptor.processRequest(mockInput)).thenReturn(mockInput);
+
         Exception e = new IllegalStateException();
-        doThrow(e).when(chainRequestInterceptor).process(any());
+        doThrow(e).when(chainRequestInterceptor).processRequest(mockInput);
         when(mockExceptionMapper.getHandler(any(), any())).thenReturn(Optional.empty());
         try {
             dispatcher.dispatch(mockInput);
             fail("Unhandled skill exception should have been thrown");
         } catch (AskSdkException ex) {
-            verify(globalRequestInterceptor).process(mockInput);
-            verify(chainRequestInterceptor).process(mockInput);
+            verify(globalRequestInterceptor).processRequest(mockInput);
+            verify(chainRequestInterceptor).processRequest(mockInput);
             verify(chainResponseInterceptor, never()).processResponse(mockInput, mockOutput);
             verify(globalResponseInterceptor, never()).processResponse(mockInput, mockOutput);
             verify(mockMapper).getRequestHandlerChain(any());
@@ -422,6 +427,9 @@ public class BaseRequestDispatcherTest {
         responseInterceptors.add(globalResponseInterceptor);
         when(mockHandlerChain.getResponseInterceptors()).thenReturn(Collections.singletonList(chainResponseInterceptor));
 
+        when(globalRequestInterceptor.processRequest(mockInput)).thenReturn(mockInput);
+        when(chainRequestInterceptor.processRequest(mockInput)).thenReturn(mockInput);
+
         Exception e = new IllegalStateException();
         when(mockAdapter.execute(any(TestHandlerInput.class), any())).thenThrow(e);
         when(mockExceptionMapper.getHandler(any(), any())).thenReturn(Optional.empty());
@@ -429,8 +437,8 @@ public class BaseRequestDispatcherTest {
             dispatcher.dispatch(mockInput);
             fail("Unhandled skill exception should have been thrown");
         } catch (AskSdkException ex) {
-            verify(globalRequestInterceptor).process(mockInput);
-            verify(chainRequestInterceptor).process(mockInput);
+            verify(globalRequestInterceptor).processRequest(mockInput);
+            verify(chainRequestInterceptor).processRequest(mockInput);
             verify(chainResponseInterceptor, never()).processResponse(mockInput, mockOutput);
             verify(globalResponseInterceptor, never()).processResponse(mockInput, mockOutput);
             verify(mockMapper).getRequestHandlerChain(any());
@@ -453,6 +461,9 @@ public class BaseRequestDispatcherTest {
         responseInterceptors.add(globalResponseInterceptor);
         when(mockHandlerChain.getResponseInterceptors()).thenReturn(Collections.singletonList(chainResponseInterceptor));
 
+        when(globalRequestInterceptor.processRequest(mockInput)).thenReturn(mockInput);
+        when(chainRequestInterceptor.processRequest(mockInput)).thenReturn(mockInput);
+
         Exception e = new IllegalStateException();
         doThrow(e).when(chainResponseInterceptor).processResponse(any(), any());
         when(mockExceptionMapper.getHandler(any(), any())).thenReturn(Optional.empty());
@@ -460,8 +471,8 @@ public class BaseRequestDispatcherTest {
             dispatcher.dispatch(mockInput);
             fail("Unhandled skill exception should have been thrown");
         } catch (AskSdkException ex) {
-            verify(globalRequestInterceptor).process(mockInput);
-            verify(chainRequestInterceptor).process(mockInput);
+            verify(globalRequestInterceptor).processRequest(mockInput);
+            verify(chainRequestInterceptor).processRequest(mockInput);
             verify(chainResponseInterceptor).processResponse(mockInput, mockOutput);
             verify(globalResponseInterceptor, never()).processResponse(mockInput, mockOutput);
             verify(mockMapper).getRequestHandlerChain(any());
@@ -484,6 +495,9 @@ public class BaseRequestDispatcherTest {
         responseInterceptors.add(globalResponseInterceptor);
         when(mockHandlerChain.getResponseInterceptors()).thenReturn(Collections.singletonList(chainResponseInterceptor));
 
+        when(globalRequestInterceptor.processRequest(mockInput)).thenReturn(mockInput);
+        when(chainRequestInterceptor.processRequest(mockInput)).thenReturn(mockInput);
+
         Exception e = new IllegalStateException();
         when(chainResponseInterceptor.processResponse(mockInput, mockOutput)).thenReturn(mockOutput);
         doThrow(e).when(globalResponseInterceptor).processResponse(any(), any());
@@ -492,8 +506,8 @@ public class BaseRequestDispatcherTest {
             dispatcher.dispatch(mockInput);
             fail("Unhandled skill exception should have been thrown");
         } catch (AskSdkException ex) {
-            verify(globalRequestInterceptor).process(mockInput);
-            verify(chainRequestInterceptor).process(mockInput);
+            verify(globalRequestInterceptor).processRequest(mockInput);
+            verify(chainRequestInterceptor).processRequest(mockInput);
             verify(chainResponseInterceptor).processResponse(mockInput, mockOutput);
             verify(globalResponseInterceptor).processResponse(mockInput, mockOutput);
             verify(mockMapper).getRequestHandlerChain(any());

--- a/ask-sdk-runtime/tst/com/amazon/ask/request/interceptor/GenericRequestInterceptorTest.java
+++ b/ask-sdk-runtime/tst/com/amazon/ask/request/interceptor/GenericRequestInterceptorTest.java
@@ -1,0 +1,35 @@
+/*
+    Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+    Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file
+    except in compliance with the License. A copy of the License is located at
+
+        http://aws.amazon.com/apache2.0/
+
+    or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for
+    the specific language governing permissions and limitations under the License.
+ */
+
+package com.amazon.ask.request.interceptor;
+
+import com.amazon.ask.sdk.TestHandlerInput;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class GenericRequestInterceptorTest {
+
+    @Test
+    public void original_request_returned_by_default() {
+        GenericRequestInterceptor<TestHandlerInput> testInterceptor
+                = new GenericRequestInterceptor<TestHandlerInput>() {
+            @Override
+            public void process(TestHandlerInput testHandlerInput) {
+            }
+        };
+        TestHandlerInput testHandlerInput = new TestHandlerInput();
+        assertEquals(testInterceptor.processRequest(testHandlerInput), testHandlerInput);
+    }
+
+}


### PR DESCRIPTION
## Description
Adds a new request interceptor method that allows the interceptor to return an updated request. This method has a default implementation in the interface to retain backwards compatibility. 

## Motivation and Context
A similar change was [recently made](https://github.com/alexa/alexa-skills-kit-sdk-for-java/pull/209) for response interceptors. This brings parity on the request interceptor side.

## Testing
Unit tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/alexa/alexa-skills-kit-sdk-for-java/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement

