### PR TITLE
Add Person ID partition key generator

### DIFF
--- a/ask-sdk-dynamodb-persistence-adapter/src/com/amazon/ask/attributes/persistence/impl/PartitionKeyGenerators.java
+++ b/ask-sdk-dynamodb-persistence-adapter/src/com/amazon/ask/attributes/persistence/impl/PartitionKeyGenerators.java
@@ -16,6 +16,7 @@ package com.amazon.ask.attributes.persistence.impl;
 import com.amazon.ask.exception.PersistenceException;
 import com.amazon.ask.model.Context;
 import com.amazon.ask.model.Device;
+import com.amazon.ask.model.Person;
 import com.amazon.ask.model.RequestEnvelope;
 import com.amazon.ask.model.User;
 import com.amazon.ask.model.interfaces.system.SystemState;
@@ -52,6 +53,21 @@ public class PartitionKeyGenerators {
                 .map(SystemState::getDevice)
                 .map(Device::getDeviceId)
                 .orElseThrow(() -> new PersistenceException("Could not retrieve device ID from request envelope to generate persistence ID"));
+    }
+
+    /**
+     * Produces a partition key from the {@link Person} ID contained in an incoming request.
+     * If the person ID is not available, the user ID will be used as fallback.
+     *
+     * @return partition key derived from person ID, if available, or user ID if person in unavailable.
+     * @throws PersistenceException if person ID cannot be retrieved and fallback to user ID fails.
+     */
+    public static Function<RequestEnvelope, String> personId() {
+        return r -> Optional.ofNullable(r).map(RequestEnvelope::getContext)
+                .map(Context::getSystem)
+                .map(SystemState::getPerson)
+                .map(Person::getPersonId)
+                .orElseGet(() -> userId().apply(r));
     }
 
 }

--- a/ask-sdk-dynamodb-persistence-adapter/tst/com/amazon/ask/attributes/persistence/impl/PartitionKeyGeneratorsTest.java
+++ b/ask-sdk-dynamodb-persistence-adapter/tst/com/amazon/ask/attributes/persistence/impl/PartitionKeyGeneratorsTest.java
@@ -16,6 +16,7 @@ package com.amazon.ask.attributes.persistence.impl;
 import com.amazon.ask.exception.PersistenceException;
 import com.amazon.ask.model.Context;
 import com.amazon.ask.model.Device;
+import com.amazon.ask.model.Person;
 import com.amazon.ask.model.RequestEnvelope;
 import com.amazon.ask.model.User;
 import com.amazon.ask.model.interfaces.system.SystemState;
@@ -119,5 +120,81 @@ public class PartitionKeyGeneratorsTest {
         RequestEnvelope env = RequestEnvelope.builder().withContext(context).build();
         PartitionKeyGenerators.deviceId().apply(env);
     }
+
+    @Test
+    public void person_id_generator_persistence_id_generated_from_person_id() {
+        String personId = "1234";
+
+        Person person = Person.builder().withPersonId(personId).build();
+        SystemState system = SystemState.builder().withPerson(person).build();
+        Context context = Context.builder().withSystem(system).build();
+        RequestEnvelope env = RequestEnvelope.builder().withContext(context).build();
+        Assert.assertEquals(PartitionKeyGenerators.personId().apply(env), personId);
+    }
+
+    @Test
+    public void person_id_generator_persistence_id_generated_from_user_id_person_id_null() {
+        String userId = "1234";
+
+        User user = User.builder().withUserId(userId).build();
+        Person person = Person.builder().withPersonId(null).build();
+        SystemState system = SystemState.builder().withPerson(person).withUser(user).build();
+        Context context = Context.builder().withSystem(system).build();
+        RequestEnvelope env = RequestEnvelope.builder().withContext(context).build();
+
+        Assert.assertEquals(PartitionKeyGenerators.personId().apply(env), userId);
+    }
+
+    @Test
+    public void person_id_generator_persistence_id_generated_from_user_id_person_null() {
+        String userId = "1234";
+
+        User user = User.builder().withUserId(userId).build();
+        SystemState system = SystemState.builder().withPerson(null).withUser(user).build();
+        Context context = Context.builder().withSystem(system).build();
+        RequestEnvelope env = RequestEnvelope.builder().withContext(context).build();
+
+        Assert.assertEquals(PartitionKeyGenerators.personId().apply(env), userId);
+    }
+
+    @Test(expected = PersistenceException.class)
+    public void person_id_generator_persistence_id_person_id_user_id_null_throws_exception() {
+        User user = User.builder().withUserId(null).build();
+        Person person = Person.builder().withPersonId(null).build();
+        SystemState system = SystemState.builder().withPerson(person).withUser(user).build();
+        Context context = Context.builder().withSystem(system).build();
+        RequestEnvelope env = RequestEnvelope.builder().withContext(context).build();
+
+        PartitionKeyGenerators.personId().apply(env);
+    }
+
+    @Test(expected = PersistenceException.class)
+    public void person_id_generator_persistence_id_person_id_user_null_throws_exception() {
+        Person person = Person.builder().withPersonId(null).build();
+        SystemState system = SystemState.builder().withPerson(person).withUser(null).build();
+        Context context = Context.builder().withSystem(system).build();
+        RequestEnvelope env = RequestEnvelope.builder().withContext(context).build();
+
+        PartitionKeyGenerators.personId().apply(env);
+    }
+
+    @Test (expected = PersistenceException.class)
+    public void person_id_generator_envelope_null_throws_exception() {
+        PartitionKeyGenerators.personId().apply(null);
+    }
+
+    @Test (expected = PersistenceException.class)
+    public void person_id_generator_context_null_throws_exception() {
+        RequestEnvelope env = RequestEnvelope.builder().build();
+        PartitionKeyGenerators.personId().apply(env);
+    }
+
+    @Test (expected = PersistenceException.class)
+    public void person_id_generator_systemState_null_throws_exception() {
+        Context context = Context.builder().build();
+        RequestEnvelope env = RequestEnvelope.builder().withContext(context).build();
+        PartitionKeyGenerators.personId().apply(env);
+    }
+
 
 }


### PR DESCRIPTION
## Description
Adds a new person ID partition key generator. This makes sense for users of person ID to have an even more granular way to store attributes. If person ID is unavailable, the key will fall back to using the user ID.

## Testing
New unit tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/alexa/alexa-skills-kit-sdk-for-java/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement

