### PR TITLE
Fix typos in README.md

### DIFF
--- a/ask-smapi-sdk/README.md
+++ b/ask-smapi-sdk/README.md
@@ -97,7 +97,7 @@
 > ``` sh
 > try {
 >    SkillManifestEnvelope skillManifestEnvelope = customSmapiClient.getSkillManifestV1(skillId, "development");
-> } catch (ServcieException e) {
+> } catch (ServiceException e) {
 >    System.out.println(e.getMessage());
 > }
 > ```

--- a/ask-smapi-sdk/README.md
+++ b/ask-smapi-sdk/README.md
@@ -96,7 +96,7 @@
 > 
 > ``` sh
 > try {
->    SkillManifestEnvelope skillManifestEnvelope = customSmapiClient.getSkillManifestV1(skillId, "developement");
+>    SkillManifestEnvelope skillManifestEnvelope = customSmapiClient.getSkillManifestV1(skillId, "development");
 > } catch (ServcieException e) {
 >    System.out.println(e.getMessage());
 > }
@@ -118,7 +118,7 @@
 > }
 > ```
 
-## Documentatiion
+## Documentation
 
 * [SMAPI SDK Reference Documentation]()
 * [SMAPI Documentation](https://developer.amazon.com/docs/smapi/smapi-overview.html)


### PR DESCRIPTION
## Description
This pull request fixes two typos that are present in the existing README markdown file of the maven project `ask-smapi-sdk`

## Motivation and Context
When I tried to use this library, I copied code straight from the `usage` section without any forethought and thought that it would work as expected. However, the code didn't work. At first, I thought I had done some wrong but when I took a closer look, I found a typo inside the code. And I also noticed another typo upon closer reading. And so this pull request fixes them.

## Checklist
- [ ] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## License
- [x] I confirm that this pull request can be released under the Apache 2 license