### PR TITLE
Fix NPE in viewport profile mapper for non APL requests

### DIFF
--- a/ask-sdk-core/src/com/amazon/ask/request/viewport/ViewportUtils.java
+++ b/ask-sdk-core/src/com/amazon/ask/request/viewport/ViewportUtils.java
@@ -83,89 +83,91 @@ public final class ViewportUtils {
      * @return {@link ViewportProfile}.
      */
     public static ViewportProfile getViewportProfile(final RequestEnvelope requestEnvelope) {
-        ViewportState viewportState = requestEnvelope.getContext().getViewport();
-        Shape shape = viewportState.getShape();
-        int currentPixelWidth = viewportState.getCurrentPixelWidth().intValueExact();
-        int currentPixelHeight = viewportState.getCurrentPixelHeight().intValueExact();
-        int dpi = viewportState.getDpi().intValueExact();
-        Orientation orientation = getOrientation(currentPixelHeight, currentPixelWidth);
+        if (requestEnvelope.getContext().getViewport() != null) {
+            ViewportState viewportState = requestEnvelope.getContext().getViewport();
+            Shape shape = viewportState.getShape();
+            int currentPixelWidth = viewportState.getCurrentPixelWidth().intValueExact();
+            int currentPixelHeight = viewportState.getCurrentPixelHeight().intValueExact();
+            int dpi = viewportState.getDpi().intValueExact();
+            Orientation orientation = getOrientation(currentPixelHeight, currentPixelWidth);
 
-        if (shape == Shape.ROUND
-                && orientation == Orientation.EQUAL
-                && getSize(currentPixelHeight) == Size.XSMALL
-                && getSize(currentPixelWidth) == Size.XSMALL
-                && getDensity(dpi) == Density.LOW) {
-            return ViewportProfile.HUB_ROUND_SMALL;
+            if (shape == Shape.ROUND
+                    && orientation == Orientation.EQUAL
+                    && getSize(currentPixelHeight) == Size.XSMALL
+                    && getSize(currentPixelWidth) == Size.XSMALL
+                    && getDensity(dpi) == Density.LOW) {
+                return ViewportProfile.HUB_ROUND_SMALL;
 
-        } else if (shape == Shape.RECTANGLE
-                && orientation == Orientation.LANDSCAPE
-                && getSize(currentPixelWidth).ordinal() <= Size.MEDIUM.ordinal()
-                && getSize(currentPixelHeight).ordinal() <= Size.XSMALL.ordinal()
-                && getDensity(dpi) == Density.LOW) {
-            return ViewportProfile.HUB_LANDSCAPE_SMALL;
+            } else if (shape == Shape.RECTANGLE
+                    && orientation == Orientation.LANDSCAPE
+                    && getSize(currentPixelWidth).ordinal() <= Size.MEDIUM.ordinal()
+                    && getSize(currentPixelHeight).ordinal() <= Size.XSMALL.ordinal()
+                    && getDensity(dpi) == Density.LOW) {
+                return ViewportProfile.HUB_LANDSCAPE_SMALL;
 
-        } else if (shape == Shape.RECTANGLE
-                && orientation == Orientation.LANDSCAPE
-                && getSize(currentPixelWidth).ordinal() <= Size.MEDIUM.ordinal()
-                && getSize(currentPixelHeight).ordinal() <= Size.SMALL.ordinal()
-                && getDensity(dpi) == Density.LOW) {
-            return ViewportProfile.HUB_LANDSCAPE_MEDIUM;
+            } else if (shape == Shape.RECTANGLE
+                    && orientation == Orientation.LANDSCAPE
+                    && getSize(currentPixelWidth).ordinal() <= Size.MEDIUM.ordinal()
+                    && getSize(currentPixelHeight).ordinal() <= Size.SMALL.ordinal()
+                    && getDensity(dpi) == Density.LOW) {
+                return ViewportProfile.HUB_LANDSCAPE_MEDIUM;
 
-        } else if (shape == Shape.RECTANGLE
-                && orientation == Orientation.LANDSCAPE
-                && getSize(currentPixelWidth).ordinal() >= Size.LARGE.ordinal()
-                && getSize(currentPixelHeight).ordinal() >= Size.SMALL.ordinal()
-                && getDensity(dpi) == Density.LOW) {
-            return ViewportProfile.HUB_LANDSCAPE_LARGE;
+            } else if (shape == Shape.RECTANGLE
+                    && orientation == Orientation.LANDSCAPE
+                    && getSize(currentPixelWidth).ordinal() >= Size.LARGE.ordinal()
+                    && getSize(currentPixelHeight).ordinal() >= Size.SMALL.ordinal()
+                    && getDensity(dpi) == Density.LOW) {
+                return ViewportProfile.HUB_LANDSCAPE_LARGE;
 
-        } else if (shape == Shape.RECTANGLE
-                && orientation == Orientation.LANDSCAPE
-                && getSize(currentPixelWidth).ordinal() >= Size.MEDIUM.ordinal()
-                && getSize(currentPixelHeight).ordinal() >= Size.SMALL.ordinal()
-                && getDensity(dpi) == Density.MEDIUM) {
-            return ViewportProfile.MOBILE_LANDSCAPE_MEDIUM;
+            } else if (shape == Shape.RECTANGLE
+                    && orientation == Orientation.LANDSCAPE
+                    && getSize(currentPixelWidth).ordinal() >= Size.MEDIUM.ordinal()
+                    && getSize(currentPixelHeight).ordinal() >= Size.SMALL.ordinal()
+                    && getDensity(dpi) == Density.MEDIUM) {
+                return ViewportProfile.MOBILE_LANDSCAPE_MEDIUM;
 
-        } else if (shape == Shape.RECTANGLE
-                && orientation == Orientation.PORTRAIT
-                && getSize(currentPixelWidth).ordinal() >= Size.SMALL.ordinal()
-                && getSize(currentPixelHeight).ordinal() >= Size.MEDIUM.ordinal()
-                && getDensity(dpi) == Density.MEDIUM) {
-            return ViewportProfile.MOBILE_PORTRAIT_MEDIUM;
+            } else if (shape == Shape.RECTANGLE
+                    && orientation == Orientation.PORTRAIT
+                    && getSize(currentPixelWidth).ordinal() >= Size.SMALL.ordinal()
+                    && getSize(currentPixelHeight).ordinal() >= Size.MEDIUM.ordinal()
+                    && getDensity(dpi) == Density.MEDIUM) {
+                return ViewportProfile.MOBILE_PORTRAIT_MEDIUM;
 
-        } else if (shape == Shape.RECTANGLE
-                && orientation == Orientation.LANDSCAPE
-                && getSize(currentPixelWidth).ordinal() >= Size.SMALL.ordinal()
-                && getSize(currentPixelHeight).ordinal() >= Size.XSMALL.ordinal()
-                && getDensity(dpi) == Density.MEDIUM) {
-            return ViewportProfile.MOBILE_LANDSCAPE_SMALL;
+            } else if (shape == Shape.RECTANGLE
+                    && orientation == Orientation.LANDSCAPE
+                    && getSize(currentPixelWidth).ordinal() >= Size.SMALL.ordinal()
+                    && getSize(currentPixelHeight).ordinal() >= Size.XSMALL.ordinal()
+                    && getDensity(dpi) == Density.MEDIUM) {
+                return ViewportProfile.MOBILE_LANDSCAPE_SMALL;
 
-        } else if (shape == Shape.RECTANGLE
-                && orientation == Orientation.PORTRAIT
-                && getSize(currentPixelWidth).ordinal() >= Size.XSMALL.ordinal()
-                && getSize(currentPixelHeight).ordinal() >= Size.SMALL.ordinal()
-                && getDensity(dpi) == Density.MEDIUM) {
-            return ViewportProfile.MOBILE_PORTRAIT_SMALL;
+            } else if (shape == Shape.RECTANGLE
+                    && orientation == Orientation.PORTRAIT
+                    && getSize(currentPixelWidth).ordinal() >= Size.XSMALL.ordinal()
+                    && getSize(currentPixelHeight).ordinal() >= Size.SMALL.ordinal()
+                    && getDensity(dpi) == Density.MEDIUM) {
+                return ViewportProfile.MOBILE_PORTRAIT_SMALL;
 
-        } else if (shape == Shape.RECTANGLE
-                && orientation == Orientation.LANDSCAPE
-                && getSize(currentPixelWidth).ordinal() >= Size.XLARGE.ordinal()
-                && getSize(currentPixelHeight).ordinal() >= Size.MEDIUM.ordinal()
-                && getDensity(dpi).ordinal() >= Density.HIGH.ordinal()) {
-            return ViewportProfile.TV_LANDSCAPE_XLARGE;
+            } else if (shape == Shape.RECTANGLE
+                    && orientation == Orientation.LANDSCAPE
+                    && getSize(currentPixelWidth).ordinal() >= Size.XLARGE.ordinal()
+                    && getSize(currentPixelHeight).ordinal() >= Size.MEDIUM.ordinal()
+                    && getDensity(dpi).ordinal() >= Density.HIGH.ordinal()) {
+                return ViewportProfile.TV_LANDSCAPE_XLARGE;
 
-        } else if (shape == Shape.RECTANGLE
-                && orientation == Orientation.PORTRAIT
-                && getSize(currentPixelWidth) == Size.XSMALL
-                && getSize(currentPixelHeight) == Size.XLARGE
-                && getDensity(dpi).ordinal() >= Density.HIGH.ordinal()) {
-            return ViewportProfile.TV_PORTRAIT_MEDIUM;
+            } else if (shape == Shape.RECTANGLE
+                    && orientation == Orientation.PORTRAIT
+                    && getSize(currentPixelWidth) == Size.XSMALL
+                    && getSize(currentPixelHeight) == Size.XLARGE
+                    && getDensity(dpi).ordinal() >= Density.HIGH.ordinal()) {
+                return ViewportProfile.TV_PORTRAIT_MEDIUM;
 
-        } else if (shape == Shape.RECTANGLE
-                && orientation == Orientation.LANDSCAPE
-                && getSize(currentPixelWidth) == Size.MEDIUM
-                && getSize(currentPixelHeight) == Size.SMALL
-                && getDensity(dpi).ordinal() >= Density.HIGH.ordinal()) {
-            return ViewportProfile.TV_LANDSCAPE_MEDIUM;
+            } else if (shape == Shape.RECTANGLE
+                    && orientation == Orientation.LANDSCAPE
+                    && getSize(currentPixelWidth) == Size.MEDIUM
+                    && getSize(currentPixelHeight) == Size.SMALL
+                    && getDensity(dpi).ordinal() >= Density.HIGH.ordinal()) {
+                return ViewportProfile.TV_LANDSCAPE_MEDIUM;
+            }
         }
         return ViewportProfile.UNKNOWN_VIEWPORT_PROFILE;
     }

--- a/ask-sdk-core/tst/com/amazon/ask/request/ViewportUtilsTest.java
+++ b/ask-sdk-core/tst/com/amazon/ask/request/ViewportUtilsTest.java
@@ -27,6 +27,15 @@ import static org.junit.Assert.assertEquals;
 
 public class ViewportUtilsTest {
     @Test
+    public void viewport_not_in_request_maps_to_unknown_viewport() {
+        RequestEnvelope requestEnvelope = RequestEnvelope.builder()
+        .withContext(Context.builder().build())
+        .build();
+        ViewportProfile profile = ViewportUtils.getViewportProfile(requestEnvelope);
+        assertEquals(profile, ViewportProfile.UNKNOWN_VIEWPORT_PROFILE);
+    }
+
+    @Test
     public void rook_maps_to_hub_round_small() {
         ViewportState viewportState = getViewportState("Rook");
         RequestEnvelope requestEnvelope = RequestEnvelope.builder()


### PR DESCRIPTION
## Description
Previously, if a viewport was not contained in a request (for example, a non APL enabled request) the `getViewportProfile()` method would return an NPE. This is undesirable behavior, and has been updated to return a `ViewportProfile.UNKNOWN_VIEWPORT_PROFILE` in these cases.

## Motivation and Context
User reported getting exceptions in a common flow that calls this method.

## Testing
New and existing tests pass.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/alexa/alexa-skills-kit-sdk-for-java/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement

