### PR TITLE
Update aws-lambda-java-core version and fix bug in the multiple skills usecase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ target/
 *.project
 *.classpath
 *.prefs
+*.versionsBackup

--- a/ask-sdk-core/src/com/amazon/ask/CustomSkill.java
+++ b/ask-sdk-core/src/com/amazon/ask/CustomSkill.java
@@ -126,8 +126,9 @@ public class CustomSkill extends AbstractSkill<RequestEnvelope, ResponseEnvelope
         RequestEnvelope requestEnvelope = unmarshalledRequest.getUnmarshalledRequest();
         JsonNode requestEnvelopeJson = unmarshalledRequest.getRequestJson();
 
-        if (skillId != null && !requestEnvelope.getContext().getSystem().getApplication().getApplicationId().equals(skillId)) {
-            LOGGER.debug("AlexaSkill ID verification failed.");
+        String askRequestSkillId = requestEnvelope.getContext().getSystem().getApplication().getApplicationId();
+        if (skillId != null && !askRequestSkillId.equals(skillId)) {
+            LOGGER.debug("AlexaSkill ID verification failed. Expected skillId: {} and skillId in the request: {}", skillId, askRequestSkillId);
             return null;
         }
 

--- a/ask-sdk-core/src/com/amazon/ask/CustomSkill.java
+++ b/ask-sdk-core/src/com/amazon/ask/CustomSkill.java
@@ -126,9 +126,9 @@ public class CustomSkill extends AbstractSkill<RequestEnvelope, ResponseEnvelope
         RequestEnvelope requestEnvelope = unmarshalledRequest.getUnmarshalledRequest();
         JsonNode requestEnvelopeJson = unmarshalledRequest.getRequestJson();
 
-        String askRequestSkillId = requestEnvelope.getContext().getSystem().getApplication().getApplicationId();
-        if (skillId != null && !askRequestSkillId.equals(skillId)) {
-            LOGGER.debug("AlexaSkill ID verification failed. Expected skillId: {} and skillId in the request: {}", skillId, askRequestSkillId);
+        if (skillId != null && !requestEnvelope.getContext().getSystem().getApplication().getApplicationId().equals(skillId)) {
+            LOGGER.debug("AlexaSkill ID verification failed. Expected skillId: {} and skillId in the request: {}",
+                    skillId, requestEnvelope.getContext().getSystem().getApplication().getApplicationId());
             return null;
         }
 

--- a/ask-sdk-core/src/com/amazon/ask/CustomSkill.java
+++ b/ask-sdk-core/src/com/amazon/ask/CustomSkill.java
@@ -14,7 +14,6 @@ import com.amazon.ask.util.impl.JacksonJsonUnmarshaller;
 import com.amazon.ask.attributes.persistence.PersistenceAdapter;
 import com.amazon.ask.builder.CustomSkillConfiguration;
 import com.amazon.ask.dispatcher.request.handler.HandlerInput;
-import com.amazon.ask.exception.AskSdkException;
 import com.amazon.ask.model.RequestEnvelope;
 import com.amazon.ask.model.Response;
 import com.amazon.ask.model.ResponseEnvelope;

--- a/ask-sdk-core/src/com/amazon/ask/CustomSkill.java
+++ b/ask-sdk-core/src/com/amazon/ask/CustomSkill.java
@@ -26,14 +26,22 @@ import com.amazon.ask.response.template.TemplateFactory;
 import com.amazon.ask.util.SdkConstants;
 import com.amazon.ask.util.UserAgentUtils;
 import com.fasterxml.jackson.databind.JsonNode;
+import org.slf4j.Logger;
 
 import java.util.Arrays;
 import java.util.Optional;
+
+import static org.slf4j.LoggerFactory.getLogger;
 
 /**
  * Custom type Alexa Skill.
  */
 public class CustomSkill extends AbstractSkill<RequestEnvelope, ResponseEnvelope> implements AlexaSkill<RequestEnvelope, ResponseEnvelope> {
+
+    /**
+     * Logger instance to log information for debugging purposes.
+     */
+    private static final Logger LOGGER = getLogger(CustomSkill.class);
 
     /**
      * Request Dispatcher.
@@ -119,7 +127,8 @@ public class CustomSkill extends AbstractSkill<RequestEnvelope, ResponseEnvelope
         JsonNode requestEnvelopeJson = unmarshalledRequest.getRequestJson();
 
         if (skillId != null && !requestEnvelope.getContext().getSystem().getApplication().getApplicationId().equals(skillId)) {
-            throw new AskSdkException("AlexaSkill ID verification failed.");
+            LOGGER.debug("AlexaSkill ID verification failed.");
+            return null;
         }
 
         ServiceClientFactory serviceClientFactory = apiClient != null ? ServiceClientFactory.builder()
@@ -137,7 +146,7 @@ public class CustomSkill extends AbstractSkill<RequestEnvelope, ResponseEnvelope
 
         Optional<Response> response = requestDispatcher.dispatch(handlerInput);
         return ResponseEnvelope.builder()
-                .withResponse(response != null ? response.orElse(null) : null)
+                .withResponse(response.orElse(null))
                 .withSessionAttributes(requestEnvelope.getSession() != null ? handlerInput.getAttributesManager().getSessionAttributes() : null)
                 .withVersion(SdkConstants.FORMAT_VERSION)
                 .withUserAgent(UserAgentUtils.getUserAgent(customUserAgent))

--- a/ask-sdk-core/tst/com/amazon/ask/SkillTest.java
+++ b/ask-sdk-core/tst/com/amazon/ask/SkillTest.java
@@ -98,7 +98,7 @@ public class SkillTest {
         assertEquals(responseEnvelope.getSessionAttributes(), attributes);
     }
 
-    @Test(expected = AskSdkException.class)
+    @Test
     public void given_skillId_verification_fails() {
         Optional<Response> response = Optional.of(Response.builder().build());
         when(mockAdapter.supports(any())).thenReturn(true);
@@ -115,7 +115,7 @@ public class SkillTest {
                 .withSkillId("fooId")
                 .build();
         skill= new Skill(skillConfiguration);
-        skill.invoke(envelope);
+        assertNull(skill.invoke(envelope));
     }
 
     @Test

--- a/ask-sdk-core/tst/com/amazon/ask/dispatcher/DefaultRequestDispatcherTest.java
+++ b/ask-sdk-core/tst/com/amazon/ask/dispatcher/DefaultRequestDispatcherTest.java
@@ -33,6 +33,7 @@ import com.amazon.ask.exception.UnhandledSkillException;
 import com.amazon.ask.model.IntentRequest;
 import com.amazon.ask.model.RequestEnvelope;
 import com.amazon.ask.model.Response;
+import junit.framework.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -45,6 +46,7 @@ import java.util.Optional;
 
 import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doReturn;
@@ -119,13 +121,10 @@ public class DefaultRequestDispatcherTest {
                 .build();
     }
 
-    @Test(expected = UnhandledSkillException.class)
-    public void no_handler_chain_throws_exception() {
+    @Test
+    public void no_handler_chain_returns_null() {
         when(mockMapper.getRequestHandlerChain(any(HandlerInput.class))).thenReturn(Optional.empty());
-        ArgumentCaptor<Throwable> throwableCaptor = ArgumentCaptor.forClass(Throwable.class);
-        when(mockExceptionMapper.getHandler(any(), throwableCaptor.capture())).thenReturn(Optional.empty());
-        dispatcher.dispatch(handlerInput);
-        assertTrue(throwableCaptor.getValue() instanceof AskSdkException);
+        assertNull(dispatcher.dispatch(handlerInput));
     }
 
     @Test(expected = UnhandledSkillException.class)
@@ -264,18 +263,8 @@ public class DefaultRequestDispatcherTest {
 
         when(mockMapper.getRequestHandlerChain(any())).thenReturn(Optional.empty());
         when(mockExceptionMapper.getHandler(any(), any())).thenReturn(Optional.empty());
-        try {
-            dispatcher.dispatch(handlerInput);
-            fail("Unhandled skill exception should have been thrown");
-        } catch (UnhandledSkillException ex) {
-            verify(globalRequestInterceptor).processRequest(handlerInput);
-            verify(chainRequestInterceptor, never()).processRequest(handlerInput);
-            verify(chainResponseInterceptor, never()).processResponse(handlerInput, Optional.of(mockResponse));
-            verify(globalResponseInterceptor, never()).processResponse(handlerInput, Optional.of(mockResponse));
-            verify(mockMapper).getRequestHandlerChain(any());
-            verify(mockAdapter, never()).supports(any());
-            verify(mockAdapter, never()).execute(any(), any());
-        }
+
+        assertNull(dispatcher.dispatch(handlerInput));
     }
 
     @Test

--- a/ask-sdk-lambda-support/pom.xml
+++ b/ask-sdk-lambda-support/pom.xml
@@ -42,7 +42,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-core</artifactId>
-            <version>1.0.0</version>
+            <version>1.2.1</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>

--- a/ask-sdk-lambda-support/src/com/amazon/ask/SkillStreamHandler.java
+++ b/ask-sdk-lambda-support/src/com/amazon/ask/SkillStreamHandler.java
@@ -27,7 +27,6 @@ import java.io.OutputStream;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * This class provides the handler required when hosting the service as an AWS Lambda function.

--- a/ask-sdk-lambda-support/src/com/amazon/ask/SkillStreamHandler.java
+++ b/ask-sdk-lambda-support/src/com/amazon/ask/SkillStreamHandler.java
@@ -27,6 +27,7 @@ import java.io.OutputStream;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * This class provides the handler required when hosting the service as an AWS Lambda function.
@@ -80,8 +81,9 @@ public abstract class SkillStreamHandler implements RequestStreamHandler {
     public final void handleRequest(final InputStream input, final OutputStream output, final Context context)
             throws IOException {
         byte[] inputBytes = IOUtils.toByteArray(input);
-        for (AlexaSkill skill : skills) {
-            SkillResponse response = skill.execute(new BaseSkillRequest(inputBytes), context);
+        AtomicInteger atomicInteger = new AtomicInteger(1);
+        for (int i = 0; i < skills.size(); ++i) {
+            SkillResponse response = skills.get(i).execute(new BaseSkillRequest(inputBytes), context);
             if (response != null) {
                 if (response.isPresent()) {
                     response.writeTo(output);

--- a/ask-sdk-lambda-support/src/com/amazon/ask/SkillStreamHandler.java
+++ b/ask-sdk-lambda-support/src/com/amazon/ask/SkillStreamHandler.java
@@ -81,8 +81,8 @@ public abstract class SkillStreamHandler implements RequestStreamHandler {
     public final void handleRequest(final InputStream input, final OutputStream output, final Context context)
             throws IOException {
         byte[] inputBytes = IOUtils.toByteArray(input);
-        for (int i = 0; i < skills.size(); ++i) {
-            SkillResponse response = skills.get(i).execute(new BaseSkillRequest(inputBytes), context);
+        for (AlexaSkill skill : skills) {
+            SkillResponse response = skill.execute(new BaseSkillRequest(inputBytes), context);
             if (response != null) {
                 if (response.isPresent()) {
                     response.writeTo(output);

--- a/ask-sdk-lambda-support/src/com/amazon/ask/SkillStreamHandler.java
+++ b/ask-sdk-lambda-support/src/com/amazon/ask/SkillStreamHandler.java
@@ -81,7 +81,6 @@ public abstract class SkillStreamHandler implements RequestStreamHandler {
     public final void handleRequest(final InputStream input, final OutputStream output, final Context context)
             throws IOException {
         byte[] inputBytes = IOUtils.toByteArray(input);
-        AtomicInteger atomicInteger = new AtomicInteger(1);
         for (int i = 0; i < skills.size(); ++i) {
             SkillResponse response = skills.get(i).execute(new BaseSkillRequest(inputBytes), context);
             if (response != null) {

--- a/ask-sdk-local-debug/src/com/amazon/ask/localdebug/lambdaContext/DebugLambdaContext.java
+++ b/ask-sdk-local-debug/src/com/amazon/ask/localdebug/lambdaContext/DebugLambdaContext.java
@@ -65,11 +65,17 @@ public class DebugLambdaContext implements Context {
         return null;
     }
 
+    /**
+     * Defaults to returning null cognito identity.
+     */
     @Override
     public String getInvokedFunctionArn() {
         return null;
     }
 
+    /**
+     * Defaults to returning null cognito identity.
+     */
     @Override
     public CognitoIdentity getIdentity() {
         return null;

--- a/ask-sdk-local-debug/src/com/amazon/ask/localdebug/lambdaContext/DebugLambdaContext.java
+++ b/ask-sdk-local-debug/src/com/amazon/ask/localdebug/lambdaContext/DebugLambdaContext.java
@@ -46,6 +46,16 @@ public class DebugLambdaContext implements Context {
     }
 
     @Override
+    public String getFunctionVersion() {
+        return null;
+    }
+
+    @Override
+    public String getInvokedFunctionArn() {
+        return null;
+    }
+
+    @Override
     public CognitoIdentity getIdentity() {
         return null;
     }

--- a/ask-sdk-local-debug/src/com/amazon/ask/localdebug/lambdaContext/DebugLambdaContext.java
+++ b/ask-sdk-local-debug/src/com/amazon/ask/localdebug/lambdaContext/DebugLambdaContext.java
@@ -58,7 +58,7 @@ public class DebugLambdaContext implements Context {
     }
 
     /**
-     * Defaults to returning null cognito identity.
+     * Defaults to returning null function version.
      */
     @Override
     public String getFunctionVersion() {
@@ -66,7 +66,7 @@ public class DebugLambdaContext implements Context {
     }
 
     /**
-     * Defaults to returning null cognito identity.
+     * Defaults to returning null invoked function ARN.
      */
     @Override
     public String getInvokedFunctionArn() {

--- a/ask-sdk-runtime/src/com/amazon/ask/impl/AbstractSkill.java
+++ b/ask-sdk-runtime/src/com/amazon/ask/impl/AbstractSkill.java
@@ -82,6 +82,10 @@ public abstract class AbstractSkill<Request, Response> implements AlexaSkill<Req
         }
 
         Response response = invoke(deserializedRequest.get(), context);
+        if (response == null) {
+            return null;
+        }
+
         return new BaseSkillResponse<>(marshaller, response);
     }
 

--- a/ask-sdk-runtime/src/com/amazon/ask/request/dispatcher/impl/BaseRequestDispatcher.java
+++ b/ask-sdk-runtime/src/com/amazon/ask/request/dispatcher/impl/BaseRequestDispatcher.java
@@ -145,8 +145,8 @@ public class BaseRequestDispatcher<Input, Output> implements GenericRequestDispa
             LOGGER.debug("Found matching handler");
         } else {
             String message = "Unable to find a suitable request handler";
-            LOGGER.error(message);
-            throw new AskSdkException(message);
+            LOGGER.debug(message);
+            return null;
         }
 
         Object requestHandler = handlerChain.get().getRequestHandler();

--- a/ask-sdk-runtime/tst/com/amazon/ask/request/dispatcher/BaseRequestDispatcherTest.java
+++ b/ask-sdk-runtime/tst/com/amazon/ask/request/dispatcher/BaseRequestDispatcherTest.java
@@ -38,6 +38,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
@@ -109,13 +110,10 @@ public class BaseRequestDispatcherTest {
                 .build();
     }
 
-    @Test(expected = AskSdkException.class)
-    public void no_handler_chain_throws_exception() {
+    @Test
+    public void no_handler_chain_returns_null() {
         when(mockMapper.getRequestHandlerChain(any(TestHandlerInput.class))).thenReturn(Optional.empty());
-        ArgumentCaptor<Throwable> throwableCaptor = ArgumentCaptor.forClass(Throwable.class);
-        when(mockExceptionMapper.getHandler(any(), throwableCaptor.capture())).thenReturn(Optional.empty());
-        dispatcher.dispatch(mockInput);
-        assertTrue(throwableCaptor.getValue() instanceof AskSdkException);
+        assertNull(dispatcher.dispatch(mockInput));
     }
 
     @Test(expected = AskSdkException.class)
@@ -308,18 +306,7 @@ public class BaseRequestDispatcherTest {
 
         when(mockMapper.getRequestHandlerChain(any())).thenReturn(Optional.empty());
         when(mockExceptionMapper.getHandler(any(), any())).thenReturn(Optional.empty());
-        try {
-            dispatcher.dispatch(mockInput);
-            fail("Unhandled skill exception should have been thrown");
-        } catch (AskSdkException ex) {
-            verify(globalRequestInterceptor).processRequest(mockInput);
-            verify(chainRequestInterceptor, never()).processRequest(mockInput);
-            verify(chainResponseInterceptor, never()).processResponse(mockInput, mockOutput);
-            verify(globalResponseInterceptor, never()).processResponse(mockInput, mockOutput);
-            verify(mockMapper).getRequestHandlerChain(any());
-            verify(mockAdapter, never()).supports(any());
-            verify(mockAdapter, never()).execute(any(), any());
-        }
+        assertNull(dispatcher.dispatch(mockInput));
     }
 
     @Test

--- a/ask-sdk-servlet-support/src/com/amazon/ask/servlet/SkillServlet.java
+++ b/ask-sdk-servlet-support/src/com/amazon/ask/servlet/SkillServlet.java
@@ -178,6 +178,10 @@ public class SkillServlet extends HttpServlet {
             if (skillResponse.isPresent()) {
                 skillResponse.writeTo(output);
             }
+        } else {
+            String message = "Unable to find a suitable request handler";
+            LOGGER.error(message);
+            throw new AskSdkException(message);
         }
     }
 

--- a/ask-sdk-servlet-support/tst/com/amazon/ask/servlet/SkillServletTest.java
+++ b/ask-sdk-servlet-support/tst/com/amazon/ask/servlet/SkillServletTest.java
@@ -90,6 +90,17 @@ public class SkillServletTest extends SkillServletTestBase {
     }
 
     @Test
+    public void doPost_sdkException_responseNull_throwsInternalServiceException() throws Exception {
+        SkillServlet servlet = new SkillServlet(skill, Collections.emptyList());
+        when(skill.execute(any())).thenReturn(null);
+        OffsetDateTime timestamp = OffsetDateTime.ofInstant(new Date().toInstant(), ZoneId.systemDefault());
+        LaunchRequest request = LaunchRequest.builder().withRequestId("rId").withLocale(LOCALE).withTimestamp(timestamp).build();
+        ServletInvocationParameters invocation = build(FORMAT_VERSION, request, buildSession());
+        servlet.doPost(invocation.request, invocation.response);
+        verify(invocation.response).sendError(eq(HttpServletResponse.SC_INTERNAL_SERVER_ERROR), anyString());
+    }
+
+    @Test
     public void skill_response_returns_payload() throws Exception {
         SkillServlet servlet = new SkillServlet(skill, Collections.emptyList());
         Response response = Response.builder().build();

--- a/ask-sdk-servlet-support/tst/com/amazon/ask/servlet/SkillServletTest.java
+++ b/ask-sdk-servlet-support/tst/com/amazon/ask/servlet/SkillServletTest.java
@@ -66,18 +66,6 @@ public class SkillServletTest extends SkillServletTestBase {
     }
 
     @Test
-    public void doPost_passedVerification_responseSuccess() throws Exception {
-        SkillServletVerifier mockVerifier = mock(SkillServletVerifier.class);
-        SkillServlet servlet = new SkillServlet(skill, Collections.singletonList(mockVerifier));
-        OffsetDateTime timestamp = OffsetDateTime.ofInstant(new Date().toInstant(), ZoneId.systemDefault());
-        LaunchRequest request = LaunchRequest.builder().withRequestId("rId").withLocale(LOCALE).withTimestamp(timestamp).build();
-        ServletInvocationParameters invocation = build(FORMAT_VERSION, request, buildSession());
-        servlet.doPost(invocation.request, invocation.response);
-        verify(invocation.response).setStatus(HttpServletResponse.SC_OK);
-        verify(mockVerifier).verify(any());
-    }
-
-    @Test
     public void doPost_failedVerification_responseBadRequest() throws Exception {
         SkillServletVerifier mockVerifier = mock(SkillServletVerifier.class);
         doThrow(new SecurityException("foo")).when(mockVerifier).verify(any());
@@ -113,6 +101,7 @@ public class SkillServletTest extends SkillServletTestBase {
         servlet.doPost(invocation.request, invocation.response);
         byte[] output = invocation.output.toByteArray();
         assertTrue(output.length > 0);
+        verify(invocation.response).setStatus(HttpServletResponse.SC_OK);
     }
 
     @Test


### PR DESCRIPTION
1. Update aws-lambda-java-core version with related code changes
2. Fix bug to ensure multiple skills usecase behaves as expected
3. If skillId in the ASK request doesn't match the one used when initializing the skill, let the fallthrough happen to the next skill.

## Description
1. The change updates aws-lambda-java-core and applies code changes required to build successfully post the version upgrade.
2. We have a usecase where we chose to host multiple skills as part of the same application using this skills stream handler constructor: https://github.com/alexa/alexa-skills-kit-sdk-for-java/blob/2.0.x/ask-sdk-lambda-support/src/com/amazon/ask/SkillStreamHandler.java#L65. When we try to invoke the second skill within that handler we see an exception "com.amazon.ask.exception.UnhandledSkillException: Unhandled exception" in our logs. Upon debugging, the issue seems to be when running multiple skills, the second skill's (possibly any skills apart from the first skill in the list) handlers are ignored.
3. If skillId in the ASK request doesn't match the one used when initializing the skill, let the fallthrough happen to the next skill. Only fail will all skillIds in the list don't match the skillId in the ASK request. Fixing the workflow [here](https://github.com/alexa/alexa-skills-kit-sdk-for-java/blob/d60b98038a2e20ae58e8652521e6cf6f7d98b034/ask-sdk-core/src/com/amazon/ask/CustomSkill.java#L121-L123) by not throwing and exception but returning a null to be handled as appropriate.

## Motivation and Context
When trying to build with this project as a dependency on Android platform the build fails with "The prefix "xsi" for attribute "xsi:schemaLocation" associated with an element type "project" is not bound". 
Root cause: without these declarations, the XML file cannot be validated correctly. 
Refer: https://github.com/aws/aws-lambda-java-libs/issues/89

As a work around, for now, currently we are excluding the aws-lambda-java-core dependency and forcing the new version to be used during build. But this proposed change will allow us to clean up that work around.

## Testing
Built using mvn clean install. Built successfully.
Tested by running two skills within the same application and both skills executed as expected.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [X ] I have added tests to cover my changes
- [x ] All new and existing tests passed

## License
- [ x] By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

[issues]: https://github.com/alexa/alexa-skills-kit-sdk-for-java/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement

