### PR TITLE
Remove redundant ObjectMapper setup from core

### DIFF
--- a/ask-sdk-core/src/com/amazon/ask/util/JacksonSerializer.java
+++ b/ask-sdk-core/src/com/amazon/ask/util/JacksonSerializer.java
@@ -15,11 +15,8 @@ package com.amazon.ask.util;
 
 import com.amazon.ask.model.services.Serializer;
 import com.amazon.ask.exception.AskSdkException;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.amazon.ask.util.impl.ObjectMapperFactory;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -33,13 +30,7 @@ public final class JacksonSerializer implements Serializer {
     /**
      * Mapper used to serialize and de-serialize objects and byte streams respectively.
      */
-    private static ObjectMapper mapper = new ObjectMapper();
-    static {
-        mapper.setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
-        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-        mapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
-        mapper.registerModule(new JavaTimeModule());
-    }
+    private static ObjectMapper mapper = ObjectMapperFactory.getMapper();
 
     /**
      * For testing purposes.


### PR DESCRIPTION
## Motivation and Context
Remove duplication for ObjectMapper setup

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
- [x] By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

[issues]: https://github.com/alexa/alexa-skills-kit-sdk-for-java/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement

