### PR TITLE
Remove Log4j implementation component from the sdk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ target/
 *.classpath
 *.prefs
 *.versionsBackup
+*.vscode/

--- a/ask-sdk-core/pom.xml
+++ b/ask-sdk-core/pom.xml
@@ -56,9 +56,9 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j-impl</artifactId>
-      <version>2.17.0</version>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>1.7.10</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/ask-sdk-freemarker/pom.xml
+++ b/ask-sdk-freemarker/pom.xml
@@ -57,9 +57,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
-            <version>2.17.0</version>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.10</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/ask-sdk-local-debug/pom.xml
+++ b/ask-sdk-local-debug/pom.xml
@@ -78,9 +78,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
-            <version>2.17.0</version>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.10</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/ask-sdk-runtime/pom.xml
+++ b/ask-sdk-runtime/pom.xml
@@ -65,12 +65,6 @@
             <version>4.13.1</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
-            <version>2.17.0</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>

--- a/ask-sdk-servlet-support/pom.xml
+++ b/ask-sdk-servlet-support/pom.xml
@@ -86,9 +86,9 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j-impl</artifactId>
-      <version>2.17.0</version>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>1.7.10</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/ask-sdk/pom.xml
+++ b/ask-sdk/pom.xml
@@ -77,9 +77,9 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j-impl</artifactId>
-      <version>2.17.0</version>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>1.7.10</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Remove the log4j implementation component from the SDK entirely. 

## Motivation and Context

Some SDK users use different logging SLF4j implementation other than Log4j. This change allows them to use our SDK jar file without any dependencies on Log4j components. 

## Testing

Generated a super jar for a skill developer who doesn't use Log4j and got a confirmation they were able to publish without the log4j component blocking their prod deployment. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
- [x] By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

[issues]: https://github.com/alexa/alexa-skills-kit-sdk-for-java/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement

