### PR TITLE
fix removing slf4j test scope due to runtime errors

### DIFF
--- a/ask-sdk-core/pom.xml
+++ b/ask-sdk-core/pom.xml
@@ -59,7 +59,6 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <version>1.7.10</version>
-      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/ask-sdk-freemarker/pom.xml
+++ b/ask-sdk-freemarker/pom.xml
@@ -60,7 +60,6 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>1.7.10</version>
-            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/ask-sdk-local-debug/pom.xml
+++ b/ask-sdk-local-debug/pom.xml
@@ -81,7 +81,6 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>1.7.10</version>
-            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/ask-sdk-servlet-support/pom.xml
+++ b/ask-sdk-servlet-support/pom.xml
@@ -89,7 +89,6 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <version>1.7.10</version>
-      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/ask-sdk/pom.xml
+++ b/ask-sdk/pom.xml
@@ -80,7 +80,6 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <version>1.7.10</version>
-      <scope>test</scope>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
mvn clean compile was failing after the log4j implementation removal.  This was most likely due to the fact that these were scoped to Test.  This change removes the limited scope

## Testing
was able to run the mvn compile commands that were failing.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
- [x] By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

[issues]: https://github.com/alexa/alexa-skills-kit-sdk-for-java/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement

