### PR TITLE
fix: upgrade server algorithm validation

### DIFF
--- a/ask-sdk-servlet-support/src/com/amazon/ask/servlet/ServletConstants.java
+++ b/ask-sdk-servlet-support/src/com/amazon/ask/servlet/ServletConstants.java
@@ -30,7 +30,7 @@ public final class ServletConstants {
     /**
      * The algorithm used to generate the signature.
      */
-    public static final String SIGNATURE_ALGORITHM = "SHA1withRSA";
+    public static final String SIGNATURE_ALGORITHM = "SHA256withRSA";
 
     /**
      * The character encoding used.
@@ -55,7 +55,7 @@ public final class ServletConstants {
     /**
      * The name of the request header that contains the signature.
      */
-    public static final String SIGNATURE_REQUEST_HEADER = "Signature";
+    public static final String SIGNATURE_REQUEST_HEADER = "Signature-256";
 
     /**
      * The name of the request header that contains the URL for the certificate chain needed to


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Upgrading the ASK SDK Java Servlets skill request signature verification handler to use the SHA256withRSA signature algorithm using the Signature-256 request header in order to validate the request is a valid Alexa HTTP requests. 

## Motivation and Context
This change is part of a multi-phase effort to move off of SHA-1 algorithm for all tls usage.


## Testing


## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project
- [X] My change requires a change to the documentation
- [X] I have updated the documentation accordingly
- [X] I have read the **README** document
- [ ] I have added tests to cover my changes
Current tests are leveraging the constants that have been updated in this PR so no changes made 
- [X] All new and existing tests passed

## License
- [X] By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

[issues]: https://github.com/alexa/alexa-skills-kit-sdk-for-java/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement

