### PR TITLE
add a test case to cover apl commands value support for both integers…

### DIFF
--- a/ask-sdk-core/tst/com/amazon/ask/util/JacksonSerializerTest.java
+++ b/ask-sdk-core/tst/com/amazon/ask/util/JacksonSerializerTest.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Before;
 import org.junit.Test;
@@ -30,6 +31,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -105,6 +107,18 @@ public class JacksonSerializerTest {
         InputStream is = mock(InputStream.class);
         when(mockMapper.readValue(is, RequestEnvelope.class)).thenReturn(requestEnvelope);
         assertEquals(serializer.deserialize(is, RequestEnvelope.class), requestEnvelope);
+    }
+
+    @Test
+    public void deserialize_from_integer_string_value_of_apl_command() throws IOException {
+        String expression = "{\"version\":\"1.0\",\"sessionAttributes\":{},"
+            + "\"userAgent\":\"ask-java/2.37.1 Java/1.8.0_322 templateResolver\","
+            + "\"response\":{\"directives\":[{\"type\":\"Alexa.Presentation.APL.ExecuteCommands\","
+            + "\"commands\":[{\"type\":\"Scroll\",\"distance\":\"75%\",\"componentId\":\"scrollComponent\"}],"
+            + "\"token\":\"kitchen-conversations\"}],\"apiResponse\":{\"status\":\"SUCCESS\","
+            + "\"experienceType\":\"MULTI_MODAL\",\"direction\":\"down\"}}}";
+        ObjectMapper mapper = new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        assertNotNull(mapper.readValue(expression, ResponseEnvelope.class));
     }
 
     @Test(expected = AskSdkException.class)


### PR DESCRIPTION
… and strings expressions

<!--- Provide a general summary of your changes in the Title above -->

## Description

The PR adds a unit test to validate the support of expressions, ie 75% in some annotated fields.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->

There was a fix in our model generators that caused deserialization errors when these expressions were used in this manner.  The issue has been resolved, adding a test here to confirm the behavior and prevent regression. 

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
tests pass locally + tests without the fix fail. 
Also it was confirmed (by Shreyas) with the team reporting this issue that the fix worked.


## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [tbd] All new and existing tests passed

## License
- [x] By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

[issues]: https://github.com/alexa/alexa-skills-kit-sdk-for-java/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement

