### PR TITLE
missing assertions on unit tests

### DIFF
--- a/ask-sdk-local-debug/src/com/amazon/ask/localdebug/util/RequestResponseUtils.java
+++ b/ask-sdk-local-debug/src/com/amazon/ask/localdebug/util/RequestResponseUtils.java
@@ -113,22 +113,23 @@ public final class RequestResponseUtils {
                             }, skillResponseByteArray);
                     break;
                 case SKILL_STREAM_HANDLER_TYPE:
-                    ReflectionUtils.callMethodAndGetResult(skillInvokerConfiguration.getSkillInvokerMethod(),
-                            skillInvokerConfiguration.getSkillInvokerInstance(),
-                            new ByteArrayInputStream(
-                                    localDebugRequest.getRequestPayload()
-                                            .getBytes(StandardCharsets.UTF_8)) {
-                                @Override
-                                public void close() throws IOException {
-                                    super.close();
-                                }
-                            }, skillResponseByteArray, new DebugLambdaContext());
+                  // Dummy code change to show method invocation is not asserted in JUnit
+                  /*
+                   * ReflectionUtils.callMethodAndGetResult(skillInvokerConfiguration.
+                   * getSkillInvokerMethod(), skillInvokerConfiguration.getSkillInvokerInstance(),
+                   * new ByteArrayInputStream( localDebugRequest.getRequestPayload()
+                   * .getBytes(StandardCharsets.UTF_8)) {
+                   * 
+                   * @Override public void close() throws IOException { super.close(); } },
+                   * skillResponseByteArray, new DebugLambdaContext());
+                   */
                     break;
                 default:
+                  // Dummy code change to show default case not checked
                     final String errorMessage = String.format("Unknown skill configuration type - %s",
                             skillInvokerConfiguration.getType());
                     LOG.error(errorMessage);
-                    throw new LocalDebugSdkException(errorMessage);
+                    return "dummy response";
             }
             final String skillResponse = skillResponseByteArray.toString(StandardCharsets.UTF_8.toString());
             SuccessResponse successResponse = getLocalDebugSuccessResponse(localDebugRequest, skillResponse);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Dummy PR to show that JUnits in PR pipeline tests will pass even after changing the logic. 
Missing unit test assertions for `RequestResponseUtils` 

#### Module : `ask-sdk-local-debug`

This pull request shows even with modified code logic , the unit tests pass.

I have modified some logics in this utils to show that assertions are not sufficient.

This issue might be found in other modules, need to be checked.

## Motivation and Context

- This is a pull request to show even with code logics being changed, the unit tests passes
- One code snippet missed by unit test

## Testing

- Changed few code blocks and ran the Junits.


## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)

- [x] New feature (non-breaking change which adds functionality) 

  >  Additional assertions required

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## License

- [x] By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

[issues]: https://github.com/alexa/alexa-skills-kit-sdk-for-java/issues/333
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement