### PR TITLE
GH-335: migrate from Java EE to Jakarta EE

### DIFF
--- a/ask-sdk-servlet-support/pom.xml
+++ b/ask-sdk-servlet-support/pom.xml
@@ -40,9 +40,9 @@
       <version>2.86.0</version>
     </dependency>
     <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
-      <version>3.0.1</version>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <version>6.0.0</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/ask-sdk-servlet-support/src/com/amazon/ask/servlet/SkillServlet.java
+++ b/ask-sdk-servlet-support/src/com/amazon/ask/servlet/SkillServlet.java
@@ -13,22 +13,6 @@
 
 package com.amazon.ask.servlet;
 
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.InputStream;
-import java.io.IOException;
-import java.io.NotSerializableException;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
-import java.io.OutputStream;
-import java.net.Proxy;
-import java.util.ArrayList;
-import java.util.List;
-
 import com.amazon.ask.Skill;
 import com.amazon.ask.exception.AskSdkException;
 import com.amazon.ask.model.RequestEnvelope;
@@ -36,15 +20,19 @@ import com.amazon.ask.model.services.Serializer;
 import com.amazon.ask.request.impl.BaseSkillRequest;
 import com.amazon.ask.response.SkillResponse;
 import com.amazon.ask.servlet.util.ServletUtils;
-import com.amazon.ask.servlet.verifiers.AlexaHttpRequest;
-import com.amazon.ask.servlet.verifiers.ServletRequest;
-import com.amazon.ask.servlet.verifiers.SkillRequestSignatureVerifier;
-import com.amazon.ask.servlet.verifiers.SkillRequestTimestampVerifier;
-import com.amazon.ask.servlet.verifiers.SkillServletVerifier;
+import com.amazon.ask.servlet.verifiers.*;
 import com.amazon.ask.util.JacksonSerializer;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.*;
+import java.net.Proxy;
+import java.util.ArrayList;
+import java.util.List;
 
 import static com.amazon.ask.servlet.ServletConstants.DEFAULT_TOLERANCE_MILLIS;
 
@@ -58,7 +46,6 @@ import static com.amazon.ask.servlet.ServletConstants.DEFAULT_TOLERANCE_MILLIS;
  * invocation of the right method of the provided {@code Skill} . It also handles sending back
  * modified session attributes, user attributes and authentication tokens when needed and handles
  * exception cases.
- *
  */
 public class SkillServlet extends HttpServlet {
     /**
@@ -90,6 +77,7 @@ public class SkillServlet extends HttpServlet {
 
     /**
      * Constructor to build an instance of SkillServlet.
+     *
      * @param skill an Alexa skill instance.
      */
     public SkillServlet(final Skill skill) {
@@ -106,7 +94,8 @@ public class SkillServlet extends HttpServlet {
 
     /**
      * Constructor to build an instance of SkillServlet.
-     * @param skill instance of {@link Skill}.
+     *
+     * @param skill     instance of {@link Skill}.
      * @param verifiers list of {@link SkillServletVerifier}.
      */
     SkillServlet(final Skill skill, final List<SkillServletVerifier> verifiers) {
@@ -166,7 +155,7 @@ public class SkillServlet extends HttpServlet {
      * {@code SkillServlet} determines the type of request and passes the request to
      * the configured {@code Skill}.
      *
-     * @param input - input stream of the request.
+     * @param input  - input stream of the request.
      * @param output - output stream of the response.
      * @throws IOException if an input or output error is detected when the servlet handles the request
      */
@@ -198,8 +187,9 @@ public class SkillServlet extends HttpServlet {
 
     /**
      * Method throws an {@link NotSerializableException} if the servlet is not serializable.
+     *
      * @param in instance of {@link ObjectInputStream}.
-     * @throws IOException I/O exception.
+     * @throws IOException            I/O exception.
      * @throws ClassNotFoundException cannot a class through its fully-qualified name and can not find its definition on the classpath.
      */
     private void readObject(final ObjectInputStream in) throws IOException, ClassNotFoundException {
@@ -208,6 +198,7 @@ public class SkillServlet extends HttpServlet {
 
     /**
      * Method throws an {@link NotSerializableException} if the servlet is not serializable.
+     *
      * @param out instance of {@link ObjectOutputStream}.
      * @throws IOException I/O exception.
      */

--- a/ask-sdk-servlet-support/src/com/amazon/ask/servlet/verifiers/ServletRequest.java
+++ b/ask-sdk-servlet-support/src/com/amazon/ask/servlet/verifiers/ServletRequest.java
@@ -15,8 +15,7 @@ package com.amazon.ask.servlet.verifiers;
 
 import com.amazon.ask.model.RequestEnvelope;
 import com.amazon.ask.servlet.ServletConstants;
-
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 
 /**
  * Servlet specific implementation of {@link AlexaHttpRequest}.
@@ -45,8 +44,9 @@ public class ServletRequest implements AlexaHttpRequest {
 
     /**
      * Constructor to build an instance of ServletRequest.
-     * @param httpServletRequest instance of type {@link HttpServletRequest}.
-     * @param serializedRequestEnvelope serialized request envelope.
+     *
+     * @param httpServletRequest          instance of type {@link HttpServletRequest}.
+     * @param serializedRequestEnvelope   serialized request envelope.
      * @param deserializedRequestEnvelope de-serialized request envelope.
      */
     public ServletRequest(final HttpServletRequest httpServletRequest, final byte[] serializedRequestEnvelope,

--- a/ask-sdk-servlet-support/tst/com/amazon/ask/servlet/SkillServletTest.java
+++ b/ask-sdk-servlet-support/tst/com/amazon/ask/servlet/SkillServletTest.java
@@ -13,27 +13,16 @@
 
 package com.amazon.ask.servlet;
 
-import static com.amazon.ask.util.SdkConstants.FORMAT_VERSION;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-import static org.powermock.api.mockito.PowerMockito.doThrow;
-
-import javax.servlet.http.HttpServletResponse;
-
 import com.amazon.ask.Skill;
 import com.amazon.ask.exception.AskSdkException;
 import com.amazon.ask.model.LaunchRequest;
 import com.amazon.ask.model.Response;
 import com.amazon.ask.model.ResponseEnvelope;
+import com.amazon.ask.response.impl.BaseSkillResponse;
 import com.amazon.ask.servlet.verifiers.SkillRequestSignatureVerifier;
 import com.amazon.ask.servlet.verifiers.SkillServletVerifier;
-import com.amazon.ask.response.impl.BaseSkillResponse;
 import com.amazon.ask.util.impl.JacksonJsonMarshaller;
+import jakarta.servlet.http.HttpServletResponse;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -48,6 +37,12 @@ import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.util.Collections;
 import java.util.Date;
+
+import static com.amazon.ask.util.SdkConstants.FORMAT_VERSION;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+import static org.powermock.api.mockito.PowerMockito.doThrow;
 
 /**
  * Tests that the {@link SkillServlet} respects the provided environment variables controlling

--- a/ask-sdk-servlet-support/tst/com/amazon/ask/servlet/verifiers/SkillRequestTimestampVerifierTest.java
+++ b/ask-sdk-servlet-support/tst/com/amazon/ask/servlet/verifiers/SkillRequestTimestampVerifierTest.java
@@ -17,13 +17,12 @@ import com.amazon.ask.model.IntentRequest;
 import com.amazon.ask.model.LaunchRequest;
 import com.amazon.ask.model.RequestEnvelope;
 import com.amazon.ask.model.events.skillevents.SkillEnabledRequest;
-
+import jakarta.servlet.http.HttpServletRequest;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import javax.servlet.http.HttpServletRequest;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.util.Arrays;
@@ -38,12 +37,10 @@ import static org.mockito.Mockito.mock;
 @RunWith(Parameterized.class)
 public class SkillRequestTimestampVerifierTest {
 
-    private SkillRequestTimestampVerifier verifier;
-
     private static final long TOLERANCE_IN_MILLIS = 2000;
-
     private static HttpServletRequest mockServletRequest;
     private static byte[] serializedRequestEnvelope;
+    private final SkillRequestTimestampVerifier verifier;
 
     public SkillRequestTimestampVerifierTest(SkillRequestTimestampVerifier verifier) {
         this.verifier = verifier;
@@ -60,7 +57,7 @@ public class SkillRequestTimestampVerifierTest {
         serializedRequestEnvelope = "".getBytes();
     }
 
-    @Test (expected = IllegalArgumentException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void construct_withNegativeTolerance_throwsIllegalArgumentException() {
         new SkillRequestTimestampVerifier(-1);
     }
@@ -115,7 +112,7 @@ public class SkillRequestTimestampVerifierTest {
         verifier.verify(new ServletRequest(mockServletRequest, serializedRequestEnvelope, RequestEnvelope.builder().withRequest(IntentRequest.builder().build()).build()));
     }
 
-    @Test (expected = IllegalArgumentException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void construct_withNullTimeUnit_throwsIllegalArgumentException() {
         new SkillRequestTimestampVerifier(TOLERANCE_IN_MILLIS / 1000, null);
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

GH-335


## Description
<!--- Describe your changes in detail -->
Migrate Java EE to Jakarta EE.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->
As the `ask-sdk-servlet-support` is mostly used in combination with `spring-boot`, to support the latest `spring-boot` releases a migration from Java EE to Jakarta EE is required.

